### PR TITLE
feat: test suite (62 tests), --format table-row, CI workflow, community leaderboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node: [18, 20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+include=dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to toolscore
+
+## Adding Your Results to the Leaderboard
+
+The community leaderboard in the README is maintained by the community — anyone can submit results.
+
+### Steps
+
+1. **Run toolscore against your model:**
+
+   ```bash
+   npx toolscore --model <provider/model-name>
+   ```
+
+   For local models via Ollama:
+   ```bash
+   npx toolscore --model ollama/llama3.1:8b
+   ```
+
+   For cloud models:
+   ```bash
+   npx toolscore --model openai/gpt-4o-mini
+   ```
+
+2. **Get your table row:**
+
+   ```bash
+   npx toolscore --model <your-model> --format table-row
+   ```
+
+   This outputs a copy-paste ready Markdown table row.
+
+3. **Open a PR:**
+   - Fork this repo
+   - Add your row to the **Community Results** table in `README.md`
+   - Submit a PR titled: `results: <model-name> — score X`
+
+### Table Format
+
+```
+| Model | Score | Grade | Selection | Args | Parallel | Refusal | Recovery | Version |
+```
+
+- **Model** — model name with provider (e.g. `ollama/llama3.1:8b`, `openai/gpt-4o`)
+- **Score** — overall score (0–100)
+- **Grade** — A/B/C/D/F
+- **Selection** — function selection accuracy score
+- **Args** — argument accuracy score
+- **Parallel** — parallel tool call score
+- **Refusal** — appropriate refusal score
+- **Recovery** — error recovery score
+- **Version** — toolscore version used (run `npx toolscore --version`)
+
+### Rules
+
+- Run toolscore with default settings (no custom configs that change test cases)
+- One row per model per hardware config — if results differ significantly across machines, note it in the PR
+- Don't submit results for models you haven't actually run
+
+### Reporting Issues
+
+If you find a test case that seems wrong, or a model parsing issue, [open an issue](https://github.com/bobhns/toolscore/issues).
+
+---
+
+Made by [bobhns](https://github.com/bobhns). Built on [verdict](https://github.com/hnshah/verdict).

--- a/README.md
+++ b/README.md
@@ -177,11 +177,16 @@ Requires Node.js 18+.
 
 ## Community Results
 
-| Model | Score | Selection | Args | Parallel | Refusal | Recovery |
-|-------|-------|-----------|------|----------|---------|----------|
-| *Submit yours via PR* | — | — | — | — | — | — |
+| Model | Score | Selection | Args | Parallel | Refusal | Recovery | Version |
+|-------|-------|-----------|------|----------|---------|----------|---------|
+| *Submit yours via PR* | — | — | — | — | — | — | — |
 
-Run `toolscore --model <your-model>` and open a PR to add your result.
+**Add your result:**
+1. Run `npx toolscore --model <your-model> --format table-row`
+2. Copy the table row from the output
+3. Open a PR adding your row
+
+The `--format table-row` output also generates a badge you can embed in your model's README.
 
 ## License
 

--- a/src/__tests__/scorer.test.ts
+++ b/src/__tests__/scorer.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest'
+import { computeScore, scoreToGrade } from '../core/scorer.js'
+import type { CaseResult, Dimension } from '../types/index.js'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function makeResult(dimension: Dimension, pass: boolean, score: number, id = 'test'): CaseResult {
+  return {
+    id,
+    dimension,
+    pass,
+    score,
+    durationMs: 100,
+    actual: { toolCalls: null, content: null },
+    expected: { calls: [] },
+  }
+}
+
+const METADATA = {
+  runId: 'run_test',
+  model: 'ollama/llama3.1:8b',
+  modelResolved: 'llama3.1:8b',
+  endpoint: 'http://localhost:11434',
+  timestamp: new Date().toISOString(),
+  durationMs: 5000,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// scoreToGrade
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('scoreToGrade', () => {
+  it('returns A for 90+', () => expect(scoreToGrade(90)).toBe('A'))
+  it('returns A for 100', () => expect(scoreToGrade(100)).toBe('A'))
+  it('returns B for 75', () => expect(scoreToGrade(75)).toBe('B'))
+  it('returns B for 89', () => expect(scoreToGrade(89)).toBe('B'))
+  it('returns C for 60', () => expect(scoreToGrade(60)).toBe('C'))
+  it('returns C for 74', () => expect(scoreToGrade(74)).toBe('C'))
+  it('returns D for 45', () => expect(scoreToGrade(45)).toBe('D'))
+  it('returns D for 59', () => expect(scoreToGrade(59)).toBe('D'))
+  it('returns F for 44', () => expect(scoreToGrade(44)).toBe('F'))
+  it('returns F for 0', () => expect(scoreToGrade(0)).toBe('F'))
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// computeScore — basic
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('computeScore — basic', () => {
+  it('returns 0 for all-fail results', () => {
+    const cases: CaseResult[] = [
+      makeResult('selection', false, 0, 'sel_1'),
+      makeResult('selection', false, 0, 'sel_2'),
+    ]
+    const result = computeScore(cases, METADATA)
+    expect(result.score).toBe(0)
+    expect(result.grade).toBe('F')
+  })
+
+  it('returns 100 for all-pass results across all dimensions', () => {
+    const cases: CaseResult[] = [
+      makeResult('selection', true, 100, 'sel_1'),
+      makeResult('args', true, 100, 'arg_1'),
+      makeResult('parallel', true, 100, 'par_1'),
+      makeResult('refusal', true, 100, 'ref_1'),
+      makeResult('recovery', true, 100, 'rec_1'),
+    ]
+    const result = computeScore(cases, METADATA)
+    expect(result.score).toBe(100)
+    expect(result.grade).toBe('A')
+  })
+
+  it('carries through metadata', () => {
+    const result = computeScore([], METADATA)
+    expect(result.runId).toBe('run_test')
+    expect(result.model).toBe('ollama/llama3.1:8b')
+    expect(result.endpoint).toBe('http://localhost:11434')
+  })
+
+  it('returns correct stats', () => {
+    const cases: CaseResult[] = [
+      makeResult('selection', true, 100, 'sel_1'),
+      makeResult('selection', false, 0, 'sel_2'),
+      makeResult('selection', false, 0, 'sel_3'),
+    ]
+    // Simulate one as error
+    cases[2].actual.error = 'API timeout'
+
+    const result = computeScore(cases, METADATA)
+    expect(result.stats.total).toBe(3)
+    expect(result.stats.passed).toBe(1)
+    expect(result.stats.failed).toBe(1) // failed but no error
+    expect(result.stats.errors).toBe(1) // has .error field
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// computeScore — weighted scoring
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('computeScore — weighted scoring', () => {
+  // Weights: selection 25%, args 30%, parallel 20%, refusal 10%, recovery 15%
+
+  it('scores 0% selection doesn\'t make overall 0 (other dims contribute)', () => {
+    const cases: CaseResult[] = [
+      makeResult('selection', false, 0, 'sel_1'),
+      makeResult('args', true, 100, 'arg_1'),
+      makeResult('parallel', true, 100, 'par_1'),
+      makeResult('refusal', true, 100, 'ref_1'),
+      makeResult('recovery', true, 100, 'rec_1'),
+    ]
+    const result = computeScore(cases, METADATA)
+    // selection = 25% weight = 0. Rest = 75%. Overall ≈ 75.
+    expect(result.score).toBe(75)
+  })
+
+  it('args dimension has 30% weight', () => {
+    const cases: CaseResult[] = [
+      makeResult('selection', true, 100, 'sel_1'),
+      makeResult('args', false, 0, 'arg_1'),
+      makeResult('parallel', true, 100, 'par_1'),
+      makeResult('refusal', true, 100, 'ref_1'),
+      makeResult('recovery', true, 100, 'rec_1'),
+    ]
+    const result = computeScore(cases, METADATA)
+    // args = 30% weight = 0. Rest = 70%. Overall ≈ 70.
+    expect(result.score).toBe(70)
+  })
+
+  it('handles partial scores within a dimension', () => {
+    // 3 selection cases: 100, 100, 0 = 67% average
+    const cases: CaseResult[] = [
+      makeResult('selection', true, 100, 'sel_1'),
+      makeResult('selection', true, 100, 'sel_2'),
+      makeResult('selection', false, 0, 'sel_3'),
+    ]
+    const result = computeScore(cases, METADATA)
+    expect(result.dimensions.selection.score).toBe(67)
+  })
+
+  it('normalizes score when only some dimensions present', () => {
+    // Only selection cases — should normalize to selection's contribution
+    const cases: CaseResult[] = [
+      makeResult('selection', true, 100, 'sel_1'),
+    ]
+    const result = computeScore(cases, METADATA)
+    // Only selection (25% weight), normalized: 100% * 1.0 = 100
+    expect(result.score).toBe(100)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// computeScore — dimension breakdown
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('computeScore — dimension breakdown', () => {
+  it('provides per-dimension results', () => {
+    const cases: CaseResult[] = [
+      makeResult('selection', true, 100, 'sel_1'),
+      makeResult('selection', false, 50, 'sel_2'),
+      makeResult('args', true, 100, 'arg_1'),
+    ]
+    const result = computeScore(cases, METADATA)
+
+    expect(result.dimensions.selection.total).toBe(2)
+    expect(result.dimensions.selection.pass).toBe(1)
+    expect(result.dimensions.selection.score).toBe(75) // (100+50)/2
+
+    expect(result.dimensions.args.total).toBe(1)
+    expect(result.dimensions.args.pass).toBe(1)
+    expect(result.dimensions.args.score).toBe(100)
+  })
+
+  it('returns 0 for dimensions with no cases', () => {
+    const cases: CaseResult[] = [makeResult('selection', true, 100, 'sel_1')]
+    const result = computeScore(cases, METADATA)
+
+    expect(result.dimensions.args.total).toBe(0)
+    expect(result.dimensions.args.score).toBe(0)
+    expect(result.dimensions.parallel.total).toBe(0)
+  })
+
+  it('includes weight for all dimensions', () => {
+    const result = computeScore([], METADATA)
+    expect(result.dimensions.selection.weight).toBe(0.25)
+    expect(result.dimensions.args.weight).toBe(0.30)
+    expect(result.dimensions.parallel.weight).toBe(0.20)
+    expect(result.dimensions.refusal.weight).toBe(0.10)
+    expect(result.dimensions.recovery.weight).toBe(0.15)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// computeScore — grade boundary cases
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('computeScore — grade boundaries', () => {
+  function scoreWith(dimScore: number): number {
+    const cases = [makeResult('selection', dimScore >= 80, dimScore)]
+    return computeScore(cases, METADATA).score
+  }
+
+  it('grade A at 90+', () => {
+    const cases = [makeResult('selection', true, 95)]
+    const result = computeScore(cases, METADATA)
+    expect(result.grade).toBe('A')
+  })
+
+  it('grade B at 75–89', () => {
+    const cases = [makeResult('selection', true, 80)]
+    const result = computeScore(cases, METADATA)
+    expect(result.grade).toBe('B')
+  })
+
+  it('grade C at 60–74', () => {
+    const cases = [makeResult('selection', false, 65)]
+    const result = computeScore(cases, METADATA)
+    expect(result.grade).toBe('C')
+  })
+
+  it('grade F at 0', () => {
+    const result = computeScore([], METADATA)
+    expect(result.score).toBe(0)
+    expect(result.grade).toBe('F')
+  })
+})

--- a/src/__tests__/verifier.test.ts
+++ b/src/__tests__/verifier.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect } from 'vitest'
+import { verifyResponse, scoreArgs } from '../core/verifier.js'
+import type { TestCase } from '../types/index.js'
+import type { ChatCompletion } from 'openai/resources/chat/completions.js'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function makeResponse(toolCalls?: Array<{ name: string; args: Record<string, unknown> }>, content?: string): ChatCompletion {
+  return {
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: 'test-model',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: content ?? null,
+          tool_calls: toolCalls?.map((tc, i) => ({
+            id: `call_${i}`,
+            type: 'function' as const,
+            function: {
+              name: tc.name,
+              arguments: JSON.stringify(tc.args),
+            },
+          })),
+        },
+        finish_reason: toolCalls?.length ? 'tool_calls' : 'stop',
+        logprobs: null,
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 10, total_tokens: 20 },
+  } as ChatCompletion
+}
+
+const WEATHER_TOOLS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_weather',
+      description: 'Get weather for a city',
+      parameters: {
+        type: 'object' as const,
+        properties: {
+          city: { type: 'string' },
+          units: { type: 'string', enum: ['celsius', 'fahrenheit'] },
+        },
+        required: ['city'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'search_web',
+      description: 'Search the web',
+      parameters: {
+        type: 'object' as const,
+        properties: {
+          query: { type: 'string' },
+        },
+        required: ['query'],
+      },
+    },
+  },
+]
+
+const BASE_CASE: TestCase = {
+  id: 'test_001',
+  dimension: 'selection',
+  prompt: "What's the weather in Paris?",
+  tools: WEATHER_TOOLS,
+  expected: {
+    calls: [{ name: 'get_weather', args: { city: 'Paris' }, argsMatchMode: 'subset' }],
+  },
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// verifyResponse — error handling
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('verifyResponse — error cases', () => {
+  it('returns error result when error string is passed', () => {
+    const result = verifyResponse(BASE_CASE, null, 'API timeout', 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(0)
+    expect(result.actual.error).toBe('API timeout')
+    expect(result.actual.toolCalls).toBeNull()
+  })
+
+  it('returns error result when response is null', () => {
+    const result = verifyResponse(BASE_CASE, null, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(0)
+    expect(result.actual.error).toBe('No response')
+  })
+
+  it('returns error result when choices is empty', () => {
+    const emptyResponse = { ...makeResponse(), choices: [] } as ChatCompletion
+    const result = verifyResponse(BASE_CASE, emptyResponse, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.actual.error).toBe('Empty response choices')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// verifyResponse — SELECTION dimension
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('verifyResponse — selection dimension', () => {
+  it('passes when correct tool is called', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'Paris' } }])
+    const result = verifyResponse(BASE_CASE, response, undefined, 100)
+    expect(result.pass).toBe(true)
+    expect(result.score).toBeGreaterThan(0)
+  })
+
+  it('fails when wrong tool is called', () => {
+    const response = makeResponse([{ name: 'search_web', args: { query: 'Paris weather' } }])
+    const result = verifyResponse(BASE_CASE, response, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(0)
+  })
+
+  it('fails when no tool is called', () => {
+    const response = makeResponse([], "The weather in Paris is nice today.")
+    const result = verifyResponse(BASE_CASE, response, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(0)
+    expect(result.actual.toolCalls).toBeNull()
+  })
+
+  it('passes with extra tools called (still has correct tool)', () => {
+    const response = makeResponse([
+      { name: 'get_weather', args: { city: 'Paris' } },
+      { name: 'search_web', args: { query: 'Paris' } },
+    ])
+    const result = verifyResponse(BASE_CASE, response, undefined, 100)
+    // Should still pass — correct tool was called
+    expect(result.pass).toBe(true)
+  })
+
+  it('carries dimension through result', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'Paris' } }])
+    const result = verifyResponse(BASE_CASE, response, undefined, 100)
+    expect(result.dimension).toBe('selection')
+    expect(result.id).toBe('test_001')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// verifyResponse — ARGS dimension
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('verifyResponse — args dimension', () => {
+  const argsCase: TestCase = {
+    id: 'arg_001',
+    dimension: 'args',
+    prompt: 'Get the weather in Paris in celsius',
+    tools: WEATHER_TOOLS,
+    expected: {
+      calls: [{ name: 'get_weather', args: { city: 'Paris', units: 'celsius' }, argsMatchMode: 'subset' }],
+    },
+  }
+
+  it('passes with all correct args', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'Paris', units: 'celsius' } }])
+    const result = verifyResponse(argsCase, response, undefined, 100)
+    expect(result.pass).toBe(true)
+    expect(result.score).toBe(100)
+  })
+
+  it('partial credit for partially correct args', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'Paris', units: 'fahrenheit' } }])
+    const result = verifyResponse(argsCase, response, undefined, 100)
+    expect(result.pass).toBe(false) // 50% < 80% threshold
+    expect(result.score).toBe(50)
+    expect(result.argDetails).toBeDefined()
+    expect(result.argDetails?.length).toBe(2)
+  })
+
+  it('fails with completely wrong args', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'London', units: 'fahrenheit' } }])
+    const result = verifyResponse(argsCase, response, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(0)
+  })
+
+  it('passes when extra args provided (subset mode)', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'Paris', units: 'celsius', extra: 'ignored' } }])
+    const result = verifyResponse(argsCase, response, undefined, 100)
+    expect(result.pass).toBe(true)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// verifyResponse — PARALLEL dimension
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('verifyResponse — parallel dimension', () => {
+  const parallelCase: TestCase = {
+    id: 'par_001',
+    dimension: 'parallel',
+    prompt: "What's the weather in Paris AND search the web for hotels in Paris?",
+    tools: WEATHER_TOOLS,
+    expected: {
+      calls: [
+        { name: 'get_weather', args: { city: 'Paris' }, argsMatchMode: 'subset' },
+        { name: 'search_web', args: { query: 'Paris' }, argsMatchMode: 'fuzzy' },
+      ],
+    },
+  }
+
+  it('passes when both tools called in parallel', () => {
+    const response = makeResponse([
+      { name: 'get_weather', args: { city: 'Paris' } },
+      { name: 'search_web', args: { query: 'hotels in Paris' } },
+    ])
+    const result = verifyResponse(parallelCase, response, undefined, 100)
+    expect(result.pass).toBe(true)
+    expect(result.score).toBe(100)
+  })
+
+  it('partial credit when only one tool called', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'Paris' } }])
+    const result = verifyResponse(parallelCase, response, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(50) // 1 of 2 matched
+  })
+
+  it('fails when no tools called', () => {
+    const response = makeResponse([], 'I would check the weather and search for hotels...')
+    const result = verifyResponse(parallelCase, response, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(0)
+  })
+
+  it('fails when wrong tools called', () => {
+    const response = makeResponse([
+      { name: 'wrong_tool', args: {} },
+      { name: 'another_wrong', args: {} },
+    ])
+    const result = verifyResponse(parallelCase, response, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(0)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// verifyResponse — REFUSAL dimension
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('verifyResponse — refusal dimension', () => {
+  const refusalCase: TestCase = {
+    id: 'ref_001',
+    dimension: 'refusal',
+    prompt: "What's 2 + 2?",
+    tools: WEATHER_TOOLS,
+    expected: { noCall: true },
+  }
+
+  it('passes when model does NOT call a tool', () => {
+    const response = makeResponse([], 'The answer is 4.')
+    const result = verifyResponse(refusalCase, response, undefined, 100)
+    expect(result.pass).toBe(true)
+    expect(result.score).toBe(100)
+  })
+
+  it('fails when model incorrectly calls a tool', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'Paris' } }])
+    const result = verifyResponse(refusalCase, response, undefined, 100)
+    expect(result.pass).toBe(false)
+    expect(result.score).toBe(0)
+  })
+
+  it('passes with no tool_calls field at all', () => {
+    const response = makeResponse()
+    const result = verifyResponse(refusalCase, response, undefined, 100)
+    expect(result.pass).toBe(true)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// verifyResponse — RECOVERY dimension
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('verifyResponse — recovery dimension', () => {
+  const recoveryCase: TestCase = {
+    id: 'rec_001',
+    dimension: 'recovery',
+    prompt: 'Please try again with the weather API.',
+    tools: WEATHER_TOOLS,
+    setupConversation: [
+      { role: 'user', content: "What's the weather in Paris?" },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'call_abc', type: 'function', function: { name: 'get_weather', arguments: '{"city":"Paris"}' } }],
+      },
+      { role: 'tool', tool_call_id: 'call_abc', content: 'Error: Service unavailable. Please retry.' },
+    ],
+    expected: {
+      calls: [{ name: 'get_weather', args: { city: 'Paris' }, argsMatchMode: 'subset' }],
+    },
+  }
+
+  it('passes when model retries the correct tool after error', () => {
+    const response = makeResponse([{ name: 'get_weather', args: { city: 'Paris' } }])
+    const result = verifyResponse(recoveryCase, response, undefined, 100)
+    expect(result.pass).toBe(true)
+    expect(result.dimension).toBe('recovery')
+  })
+
+  it('fails when model gives up and responds conversationally', () => {
+    const response = makeResponse([], "I'm sorry, the weather service appears to be unavailable.")
+    const result = verifyResponse(recoveryCase, response, undefined, 100)
+    expect(result.pass).toBe(false)
+  })
+
+  it('fails when model calls wrong tool on retry', () => {
+    const response = makeResponse([{ name: 'search_web', args: { query: 'Paris weather' } }])
+    const result = verifyResponse(recoveryCase, response, undefined, 100)
+    expect(result.pass).toBe(false)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// verifyResponse — content fallback parsing
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('verifyResponse — content fallback', () => {
+  it('parses tool call from content JSON when tool_calls is missing', () => {
+    const response: ChatCompletion = {
+      ...makeResponse(),
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: JSON.stringify({ name: 'get_weather', arguments: { city: 'Paris' } }),
+            tool_calls: undefined,
+          },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    } as ChatCompletion
+
+    const result = verifyResponse(BASE_CASE, response, undefined, 100)
+    // Model used content format — should still be detected
+    expect(result.actual.toolCalls).not.toBeNull()
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// scoreArgs
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('scoreArgs', () => {
+  it('returns 1.0 for empty expected args', () => {
+    const { score } = scoreArgs({ city: 'Paris' }, {}, 'subset')
+    expect(score).toBe(1)
+  })
+
+  it('subset mode: exact match scores 1.0', () => {
+    const { score } = scoreArgs({ city: 'Paris' }, { city: 'Paris' }, 'subset')
+    expect(score).toBe(1)
+  })
+
+  it('subset mode: value mismatch scores 0', () => {
+    const { score } = scoreArgs({ city: 'London' }, { city: 'Paris' }, 'subset')
+    expect(score).toBe(0)
+  })
+
+  it('subset mode: missing key scores 0', () => {
+    const { score } = scoreArgs({}, { city: 'Paris' }, 'subset')
+    expect(score).toBe(0)
+  })
+
+  it('subset mode: partial match gives partial score', () => {
+    const { score } = scoreArgs(
+      { city: 'Paris', units: 'fahrenheit' },
+      { city: 'Paris', units: 'celsius' },
+      'subset'
+    )
+    expect(score).toBe(0.5) // 1 of 2 args correct
+  })
+
+  it('exact mode: correct type wrong value gives 0.5', () => {
+    const { score } = scoreArgs({ count: 5 }, { count: 10 }, 'exact')
+    expect(score).toBe(0.5)
+  })
+
+  it('exact mode: perfect match gives 1.0', () => {
+    const { score } = scoreArgs({ count: 10 }, { count: 10 }, 'exact')
+    expect(score).toBe(1.0)
+  })
+
+  it('exact mode: type mismatch gives 0', () => {
+    const { score } = scoreArgs({ count: '10' }, { count: 10 }, 'exact')
+    expect(score).toBe(0)
+  })
+
+  it('types-only mode: same type passes', () => {
+    const { score } = scoreArgs({ city: 'London' }, { city: 'Paris' }, 'types-only')
+    expect(score).toBe(1)
+  })
+
+  it('types-only mode: different type fails', () => {
+    const { score } = scoreArgs({ city: 42 }, { city: 'Paris' }, 'types-only')
+    expect(score).toBe(0)
+  })
+
+  it('fuzzy mode: close numeric match gives 0.5', () => {
+    const { score } = scoreArgs({ value: 105 }, { value: 100 }, 'fuzzy')
+    expect(score).toBeGreaterThan(0)
+    expect(score).toBeLessThan(1)
+  })
+
+  it('fuzzy mode: string contains expected gives partial score', () => {
+    const { score } = scoreArgs({ query: 'weather in Paris today' }, { query: 'Paris' }, 'fuzzy')
+    expect(score).toBeGreaterThan(0)
+  })
+
+  it('fuzzy mode: normalized string match gives 1.0', () => {
+    const { score } = scoreArgs({ city: '  Paris  ' }, { city: 'paris' }, 'fuzzy')
+    expect(score).toBe(1)
+  })
+
+  it('returns per-arg details', () => {
+    const { details } = scoreArgs(
+      { city: 'Paris', units: 'fahrenheit' },
+      { city: 'Paris', units: 'celsius' },
+      'subset'
+    )
+    expect(details).toHaveLength(2)
+    const cityDetail = details.find(d => d.key === 'city')
+    expect(cityDetail?.score).toBe(1)
+    const unitsDetail = details.find(d => d.key === 'units')
+    expect(unitsDetail?.score).toBe(0)
+  })
+})

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander'
 import chalk from 'chalk'
 import ora from 'ora'
 import { runBenchmark } from '../core/runner.js'
-import { printScorecard, printProgress, clearProgress, toJSON, toMarkdown, toBadgeUrl, printVerboseCases } from '../reporter/index.js'
+import { printScorecard, printProgress, clearProgress, toJSON, toMarkdown, toTableRow, toBadgeUrl, printVerboseCases } from '../reporter/index.js'
 import { getCaseCounts, getAllCases } from '../cases/index.js'
 import { parseModel } from '../providers/index.js'
 import type { Dimension, RunOptions } from '../types/index.js'
@@ -25,7 +25,7 @@ program
   .option('-n, --cases <number>', 'Number of test cases to run (default: all)', parseInt)
   .option('-t, --timeout <seconds>', 'Timeout per case in seconds (default: 30)', parseInt)
   .option('-c, --concurrency <number>', 'Concurrent requests (default: 3)', parseInt)
-  .option('-f, --format <format>', 'Output format: terminal (default), json, markdown, badge')
+  .option('-f, --format <format>', 'Output format: terminal (default), json, markdown, table-row, badge')
   .option('-o, --output <file>', 'Save results to file')
   .option('--dry-run', 'Show what would run without calling the API')
   .option('--list-cases', 'List test case counts per dimension')
@@ -136,6 +136,19 @@ program.action(async (options) => {
         console.log(chalk.green(`Results saved to ${options.output}`))
       } else {
         console.log(md)
+      }
+    } else if (format === 'table-row') {
+      const row = toTableRow(result, VERSION)
+      if (options.output) {
+        fs.writeFileSync(options.output, row, 'utf8')
+        console.log(chalk.green(`Table row saved to ${options.output}`))
+      } else {
+        console.log()
+        console.log(row)
+        console.log()
+        console.log(chalk.dim('  Open a PR to add your result to the community leaderboard:'))
+        console.log(chalk.dim('  https://github.com/bobhns/toolscore#community-results'))
+        console.log()
       }
     } else if (format === 'badge') {
       const url = toBadgeUrl(result)

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -131,7 +131,7 @@ export function toJSON(result: ToolscoreResult, pretty = true): string {
 }
 
 /**
- * Render result as Markdown table
+ * Render result as Markdown full report
  */
 export function toMarkdown(result: ToolscoreResult): string {
   const { score, grade, dimensions, stats, durationMs, model, modelResolved } = result
@@ -162,6 +162,38 @@ export function toMarkdown(result: ToolscoreResult): string {
   if (stats.errors > 0) {
     lines.push(`**Errors:** ${stats.errors}`)
   }
+
+  return lines.join('\n')
+}
+
+/**
+ * Render a single community leaderboard table row for pasting into the README.
+ *
+ * Format matches the community-results table:
+ * | Model | Score | Selection | Args | Parallel | Refusal | Recovery | Version |
+ */
+export function toTableRow(result: ToolscoreResult, version: string): string {
+  const { score, grade, dimensions, model } = result
+  const d = dimensions
+
+  const sel = d.selection.total > 0 ? `${d.selection.score}%` : '—'
+  const args = d.args.total > 0 ? `${d.args.score}%` : '—'
+  const par = d.parallel.total > 0 ? `${d.parallel.score}%` : '—'
+  const ref = d.refusal.total > 0 ? `${d.refusal.score}%` : '—'
+  const rec = d.recovery.total > 0 ? `${d.recovery.score}%` : '—'
+
+  const modelDisplay = model.includes('/') ? model.split('/').slice(1).join('/') : model
+  const badgeColor = score >= 80 ? 'brightgreen' : score >= 60 ? 'yellow' : score >= 40 ? 'orange' : 'red'
+  const badge = `![${score}](https://img.shields.io/badge/toolscore-${score}%2F100-${badgeColor})`
+
+  const lines: string[] = []
+  lines.push(`<!-- paste this row into the Community Results table in README.md -->`)
+  lines.push(`| ${modelDisplay} | ${badge} | ${sel} | ${args} | ${par} | ${ref} | ${rec} | v${version} |`)
+  lines.push(``)
+  lines.push(`Badge markdown (embed in your model's README):`)
+  lines.push(`\`\`\``)
+  lines.push(`[![toolscore: ${score}/100](${toBadgeUrl(result)})](https://github.com/bobhns/toolscore)`)
+  lines.push(`\`\`\``)
 
   return lines.join('\n')
 }


### PR DESCRIPTION
## What

- **62 tests** covering all 5 dimensions, weighted scoring, grade boundaries, partial credit logic, error handling, content fallback parsing
- **`--format table-row`** — outputs a copy-paste ready community leaderboard row + badge markdown. Core viral mechanic.
- **GitHub Actions CI** — Node 18/20/22 matrix
- **Community results table** updated with `--format table-row` contribution instructions
- **CONTRIBUTING.md** — full leaderboard submission guide

## Closes

- Closes #1 (test suite)
- Closes #2 (CI workflow)
- Closes #3 (community leaderboard + CONTRIBUTING.md)
- Closes #4 (`--format markdown` table row)

## Test output

```
Test Files  2 passed (2)
     Tests  62 passed (62)
  Duration  179ms
```