### PR TITLE
feat: toolscore history — SQLite run history with filter/json/clear

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "author": "bobhns",
   "license": "MIT",
   "dependencies": {
+    "better-sqlite3": "^11.5.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "openai": "^4.67.0",
@@ -42,6 +43,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^22.0.0",
     "tsup": "^8.3.0",
     "typescript": "^5.6.0",

--- a/src/cli/history.ts
+++ b/src/cli/history.ts
@@ -1,0 +1,103 @@
+import { Command } from 'commander'
+import chalk from 'chalk'
+import { getHistory, clearHistory, dbPath } from '../core/history.js'
+
+export function makeHistoryCommand(): Command {
+  const cmd = new Command('history')
+    .description('Show past toolscore run history')
+    .option('-m, --model <model>', 'Filter by model name')
+    .option('-n, --limit <number>', 'Number of runs to show (default: 10)', parseInt)
+    .option('--json', 'Output as JSON')
+    .option('--clear', 'Delete all stored run history')
+
+  cmd.action((options) => {
+    // Clear mode
+    if (options.clear) {
+      const deleted = clearHistory()
+      console.log(chalk.green(`  Cleared ${deleted} run(s) from history`))
+      console.log(chalk.gray(`  DB: ${dbPath()}`))
+      return
+    }
+
+    const rows = getHistory({
+      model: options.model,
+      limit: options.limit ?? 10,
+    })
+
+    if (options.json) {
+      console.log(JSON.stringify(rows, null, 2))
+      return
+    }
+
+    console.log()
+    console.log(chalk.bold('  toolscore history'))
+    if (options.model) {
+      console.log(chalk.gray(`  Filtering: ${options.model}`))
+    }
+    console.log()
+
+    if (rows.length === 0) {
+      console.log(chalk.gray('  No runs found. Run toolscore to record results.'))
+      console.log()
+      return
+    }
+
+    // Header
+    console.log(
+      chalk.gray('  ') +
+      chalk.bold('Score'.padStart(6)) +
+      chalk.bold('  Grade') +
+      chalk.bold('  ' + 'Model'.padEnd(40)) +
+      chalk.bold('  When')
+    )
+    console.log(chalk.gray('  ' + '─'.repeat(75)))
+
+    for (const row of rows) {
+      const score = row.score.toFixed(1).padStart(6)
+      const grade = gradeColor(row.grade)(row.grade.padEnd(5))
+      const model = row.model.length > 38
+        ? row.model.slice(0, 35) + '...'
+        : row.model.padEnd(38)
+      const when = formatRelative(row.timestamp)
+
+      console.log(
+        chalk.gray('  ') +
+        chalk.bold(score) +
+        '  ' + grade +
+        '  ' + chalk.cyan(model) +
+        '  ' + chalk.gray(when)
+      )
+    }
+
+    console.log()
+    console.log(chalk.gray(`  ${rows.length} run(s) shown  ·  DB: ${dbPath()}`))
+    console.log()
+  })
+
+  return cmd
+}
+
+function gradeColor(grade: string): (s: string) => string {
+  switch (grade) {
+    case 'A': return chalk.green
+    case 'B': return chalk.cyan
+    case 'C': return chalk.yellow
+    case 'D': return chalk.yellow
+    default:   return chalk.red
+  }
+}
+
+function formatRelative(iso: string): string {
+  const now = Date.now()
+  const then = new Date(iso).getTime()
+  const diffMs = now - then
+  const diffMin = Math.floor(diffMs / 60_000)
+  const diffH = Math.floor(diffMin / 60)
+  const diffD = Math.floor(diffH / 24)
+
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  if (diffH < 24) return `${diffH}h ago`
+  if (diffD < 7) return `${diffD}d ago`
+  return new Date(iso).toISOString().slice(0, 10)
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,8 @@ import { getCaseCounts, getAllCases } from '../cases/index.js'
 import { parseModel } from '../providers/index.js'
 import type { Dimension, RunOptions } from '../types/index.js'
 import { VERSION } from '../version.js'
+import { saveRun } from '../core/history.js'
+import { makeHistoryCommand } from './history.js'
 import fs from 'fs'
 import path from 'path'
 
@@ -16,6 +18,9 @@ program
   .name('toolscore')
   .description('Benchmark LLM tool-calling reliability against any OpenAI-compatible endpoint')
   .version(VERSION)
+
+// Register subcommands
+program.addCommand(makeHistoryCommand())
 
 program
   .option('-m, --model <model>', 'Model to benchmark (e.g. ollama/llama3.1:8b, openai/gpt-4o)')
@@ -117,6 +122,13 @@ program.action(async (options) => {
 
     spinner.stop()
     clearProgress()
+
+    // Auto-save to history
+    try {
+      saveRun(result)
+    } catch {
+      // Never let history errors break the main flow
+    }
 
     // Output based on format
     const format = options.format ?? 'terminal'

--- a/src/core/__tests__/history.test.ts
+++ b/src/core/__tests__/history.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+// Override home dir for tests
+const TEST_HOME = path.join(os.tmpdir(), `toolscore-test-${Date.now()}`)
+process.env.HOME = TEST_HOME
+process.env.USERPROFILE = TEST_HOME // Windows
+
+// Import AFTER env override
+const { saveRun, getHistory, clearHistory, dbPath } = await import('../history.js')
+
+function makeResult(overrides: Record<string, unknown> = {}) {
+  return {
+    runId: `run_test_${Math.random().toString(36).slice(2)}`,
+    model: 'ollama/llama3.1:8b',
+    modelResolved: 'llama3.1:8b',
+    endpoint: 'http://localhost:11434/v1',
+    timestamp: new Date().toISOString(),
+    durationMs: 1234,
+    score: 75.5,
+    grade: 'B' as const,
+    dimensions: {} as never,
+    cases: [],
+    stats: { total: 50, passed: 38, failed: 12, errors: 0 },
+    ...overrides,
+  }
+}
+
+describe('history', () => {
+  beforeEach(() => {
+    fs.mkdirSync(path.join(TEST_HOME, '.toolscore'), { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true })
+    process.env.HOME = os.homedir()
+  })
+
+  it('returns empty array when no DB exists', () => {
+    expect(getHistory()).toEqual([])
+  })
+
+  it('saves a run and retrieves it', () => {
+    const r = makeResult()
+    saveRun(r)
+    const rows = getHistory()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].model).toBe(r.model)
+    expect(rows[0].score).toBe(r.score)
+    expect(rows[0].grade).toBe(r.grade)
+  })
+
+  it('returns runs ordered by timestamp desc', () => {
+    const r1 = makeResult({ timestamp: '2026-01-01T00:00:00.000Z', score: 60 })
+    const r2 = makeResult({ timestamp: '2026-01-02T00:00:00.000Z', score: 80 })
+    saveRun(r1)
+    saveRun(r2)
+    const rows = getHistory()
+    expect(rows[0].score).toBe(80)
+    expect(rows[1].score).toBe(60)
+  })
+
+  it('filters by model', () => {
+    saveRun(makeResult({ model: 'ollama/llama3.1:8b' }))
+    saveRun(makeResult({ model: 'openai/gpt-4o' }))
+    const rows = getHistory({ model: 'openai/gpt-4o' })
+    expect(rows).toHaveLength(1)
+    expect(rows[0].model).toBe('openai/gpt-4o')
+  })
+
+  it('respects limit', () => {
+    for (let i = 0; i < 5; i++) {
+      saveRun(makeResult({ score: i * 10 }))
+    }
+    const rows = getHistory({ limit: 3 })
+    expect(rows).toHaveLength(3)
+  })
+
+  it('clears history', () => {
+    saveRun(makeResult())
+    saveRun(makeResult())
+    const deleted = clearHistory()
+    expect(deleted).toBe(2)
+    expect(getHistory()).toHaveLength(0)
+  })
+
+  it('handles upsert (same runId)', () => {
+    const r = makeResult()
+    saveRun(r)
+    saveRun({ ...r, score: 99 })
+    const rows = getHistory()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].score).toBe(99)
+  })
+
+  it('dbPath returns path in home dir', () => {
+    expect(dbPath()).toContain('.toolscore')
+    expect(dbPath()).toContain('results.db')
+  })
+})

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -1,0 +1,127 @@
+import Database from 'better-sqlite3'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import type { ToolscoreResult } from '../types/index.js'
+
+const DB_DIR = path.join(os.homedir(), '.toolscore')
+const DB_PATH = path.join(DB_DIR, 'results.db')
+
+function getDb(): InstanceType<typeof Database> {
+  fs.mkdirSync(DB_DIR, { recursive: true })
+  const db = new Database(DB_PATH)
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS runs (
+      id        TEXT PRIMARY KEY,
+      model     TEXT NOT NULL,
+      endpoint  TEXT NOT NULL,
+      score     REAL NOT NULL,
+      grade     TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      duration_ms INTEGER NOT NULL,
+      result_json TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_runs_model ON runs (model);
+    CREATE INDEX IF NOT EXISTS idx_runs_timestamp ON runs (timestamp);
+  `)
+
+  return db
+}
+
+export function saveRun(result: ToolscoreResult): void {
+  const db = getDb()
+  try {
+    db.prepare(`
+      INSERT OR REPLACE INTO runs
+        (id, model, endpoint, score, grade, timestamp, duration_ms, result_json)
+      VALUES
+        (@id, @model, @endpoint, @score, @grade, @timestamp, @duration_ms, @result_json)
+    `).run({
+      id: result.runId,
+      model: result.model,
+      endpoint: result.endpoint,
+      score: result.score,
+      grade: result.grade,
+      timestamp: result.timestamp,
+      duration_ms: result.durationMs,
+      result_json: JSON.stringify(result),
+    })
+  } finally {
+    db.close()
+  }
+}
+
+export interface HistoryRow {
+  id: string
+  model: string
+  endpoint: string
+  score: number
+  grade: string
+  timestamp: string
+  durationMs: number
+}
+
+export interface HistoryOptions {
+  model?: string
+  limit?: number
+  json?: boolean
+}
+
+export function getHistory(options: HistoryOptions = {}): HistoryRow[] {
+  if (!fs.existsSync(DB_PATH)) return []
+
+  const db = getDb()
+  try {
+    let query = `
+      SELECT id, model, endpoint, score, grade, timestamp, duration_ms
+      FROM runs
+    `
+    const params: unknown[] = []
+
+    if (options.model) {
+      query += ` WHERE model = ?`
+      params.push(options.model)
+    }
+
+    query += ` ORDER BY timestamp DESC LIMIT ?`
+    params.push(options.limit ?? 10)
+
+    const rows = db.prepare(query).all(...params) as Array<{
+      id: string
+      model: string
+      endpoint: string
+      score: number
+      grade: string
+      timestamp: string
+      duration_ms: number
+    }>
+
+    return rows.map(r => ({
+      id: r.id,
+      model: r.model,
+      endpoint: r.endpoint,
+      score: r.score,
+      grade: r.grade,
+      timestamp: r.timestamp,
+      durationMs: r.duration_ms,
+    }))
+  } finally {
+    db.close()
+  }
+}
+
+export function clearHistory(): number {
+  if (!fs.existsSync(DB_PATH)) return 0
+  const db = getDb()
+  try {
+    const result = db.prepare('DELETE FROM runs').run()
+    return result.changes
+  } finally {
+    db.close()
+  }
+}
+
+export function dbPath(): string {
+  return DB_PATH
+}


### PR DESCRIPTION
Closes #5

## What

Adds `toolscore history` subcommand backed by SQLite at `~/.toolscore/results.db`.

Every successful `toolscore --model X` run is now automatically saved to history.

## Commands

```bash
# Show last 10 runs
toolscore history

# Filter by model
toolscore history --model ollama/llama3.1:8b

# Limit results
toolscore history --limit 20

# Pipe-friendly JSON
toolscore history --json

# Clear all history
toolscore history --clear
```

## What it stores

- Run ID, model, endpoint, score, grade, timestamp, duration
- Full JSON result (for future drill-down)
- Ordered by most recent first
- Upsert on same runId (idempotent)

## Files

- `src/core/history.ts` — SQLite store (save/query/clear/dbPath)
- `src/cli/history.ts` — `toolscore history` command
- `src/core/__tests__/history.test.ts` — 8 tests
- `src/cli/index.ts` — wires in history subcommand + auto-save after each run
- `package.json` — adds `better-sqlite3` + `@types/better-sqlite3`

## Tests

8 new tests covering: empty DB, save/retrieve, ordering, model filter, limit, clear, upsert, dbPath.