### PR TITLE
feat(cli): toolscore compare — side-by-side model comparison (closes #8)

### DIFF
--- a/src/cli/__tests__/compare.test.ts
+++ b/src/cli/__tests__/compare.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildCompareResult, getBiggestGap, toCompareJSON, toCompareMarkdown } from '../compare.js'
+import type { ToolscoreResult } from '../../types/index.js'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function makeResult(
+  model: string,
+  scores: Record<string, { score: number; pass: number; total: number }>,
+  overallScore: number
+): ToolscoreResult {
+  const dimensions: ToolscoreResult['dimensions'] = {} as ToolscoreResult['dimensions']
+  for (const [dim, d] of Object.entries(scores)) {
+    dimensions[dim as keyof typeof dimensions] = {
+      score: d.score,
+      pass: d.pass,
+      total: d.total,
+      weight: 1,
+    }
+  }
+
+  const passed = Object.values(scores).reduce((s, d) => s + d.pass, 0)
+  const total = Object.values(scores).reduce((s, d) => s + d.total, 0)
+
+  return {
+    runId: `run_${model}`,
+    model,
+    modelResolved: model,
+    endpoint: model.startsWith('openai/') ? 'OpenAI' : 'Ollama',
+    timestamp: new Date().toISOString(),
+    durationMs: 1000,
+    score: overallScore,
+    grade: overallScore >= 90 ? 'A' : overallScore >= 80 ? 'B' : overallScore >= 70 ? 'C' : overallScore >= 60 ? 'D' : 'F',
+    dimensions,
+    cases: [],
+    stats: { total, passed, failed: total - passed, errors: 0 },
+  }
+}
+
+const resultA = makeResult('ollama/llama3.1:8b', {
+  selection: { score: 90, pass: 9, total: 10 },
+  args: { score: 70, pass: 7, total: 10 },
+  parallel: { score: 80, pass: 4, total: 5 },
+  refusal: { score: 75, pass: 6, total: 8 },
+  recovery: { score: 38, pass: 3, total: 8 },
+}, 71)
+
+const resultB = makeResult('openai/gpt-4o-mini', {
+  selection: { score: 100, pass: 10, total: 10 },
+  args: { score: 90, pass: 9, total: 10 },
+  parallel: { score: 100, pass: 5, total: 5 },
+  refusal: { score: 100, pass: 8, total: 8 },
+  recovery: { score: 88, pass: 7, total: 8 },
+}, 95)
+
+// Tie results
+const resultTieA = makeResult('openai/gpt-4o', {
+  selection: { score: 90, pass: 9, total: 10 },
+  args: { score: 90, pass: 9, total: 10 },
+}, 90)
+
+const resultTieB = makeResult('openai/gpt-4o-mini', {
+  selection: { score: 90, pass: 9, total: 10 },
+  args: { score: 90, pass: 9, total: 10 },
+}, 90)
+
+// A wins results
+const resultAWins = makeResult('openai/gpt-4o', {
+  selection: { score: 100, pass: 10, total: 10 },
+  args: { score: 95, pass: 19, total: 20 },
+}, 98)
+
+const resultBLoses = makeResult('openai/gpt-4o-mini', {
+  selection: { score: 70, pass: 7, total: 10 },
+  args: { score: 60, pass: 12, total: 20 },
+}, 65)
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildCompareResult', () => {
+  it('detects modelB as winner', () => {
+    const result = buildCompareResult(resultA, resultB)
+    expect(result.winner).toBe('modelB')
+  })
+
+  it('detects modelA as winner', () => {
+    const result = buildCompareResult(resultAWins, resultBLoses)
+    expect(result.winner).toBe('modelA')
+  })
+
+  it('detects tie', () => {
+    const result = buildCompareResult(resultTieA, resultTieB)
+    expect(result.winner).toBe('tie')
+    expect(result.totalDiff).toBe(0)
+  })
+
+  it('calculates correct totalDiff', () => {
+    const result = buildCompareResult(resultA, resultB)
+    expect(result.totalDiff).toBe(24) // 95 - 71
+  })
+
+  it('counts dimension wins for modelB', () => {
+    const result = buildCompareResult(resultA, resultB)
+    expect(result.dimensionWins.modelB).toBe(5)
+    expect(result.dimensionWins.modelA).toBe(0)
+  })
+
+  it('counts dimension wins for modelA', () => {
+    const result = buildCompareResult(resultAWins, resultBLoses)
+    expect(result.dimensionWins.modelA).toBe(2)
+    expect(result.dimensionWins.modelB).toBe(0)
+  })
+
+  it('counts tie dimensions as 0 wins', () => {
+    const result = buildCompareResult(resultTieA, resultTieB)
+    expect(result.dimensionWins.modelA).toBe(0)
+    expect(result.dimensionWins.modelB).toBe(0)
+  })
+
+  it('includes full model results', () => {
+    const result = buildCompareResult(resultA, resultB)
+    expect(result.modelA.model).toBe('ollama/llama3.1:8b')
+    expect(result.modelB.model).toBe('openai/gpt-4o-mini')
+  })
+})
+
+describe('getBiggestGap', () => {
+  it('returns the dimension with the largest score gap', () => {
+    const gap = getBiggestGap(resultA, resultB)
+    expect(gap).not.toBeNull()
+    // recovery: |38 - 88| = 50
+    expect(gap!.dim).toBe('recovery')
+    expect(gap!.gap).toBe(50)
+  })
+
+  it('returns null when no dimensions have data', () => {
+    const emptyA = makeResult('a', {}, 0)
+    const emptyB = makeResult('b', {}, 0)
+    expect(getBiggestGap(emptyA, emptyB)).toBeNull()
+  })
+})
+
+describe('toCompareJSON', () => {
+  it('produces valid JSON with required fields', () => {
+    const compareResult = buildCompareResult(resultA, resultB)
+    const json = toCompareJSON(compareResult)
+    const parsed = JSON.parse(json)
+
+    expect(parsed).toHaveProperty('modelA')
+    expect(parsed).toHaveProperty('modelB')
+    expect(parsed).toHaveProperty('winner')
+    expect(parsed).toHaveProperty('totalDiff')
+    expect(parsed).toHaveProperty('dimensionWins')
+    expect(parsed.winner).toBe('modelB')
+    expect(parsed.totalDiff).toBe(24)
+    expect(parsed.dimensionWins.modelA).toBe(0)
+    expect(parsed.dimensionWins.modelB).toBe(5)
+  })
+
+  it('includes full ToolscoreResult in modelA and modelB', () => {
+    const compareResult = buildCompareResult(resultA, resultB)
+    const json = toCompareJSON(compareResult)
+    const parsed = JSON.parse(json)
+
+    expect(parsed.modelA.model).toBe('ollama/llama3.1:8b')
+    expect(parsed.modelB.model).toBe('openai/gpt-4o-mini')
+    expect(parsed.modelA).toHaveProperty('dimensions')
+    expect(parsed.modelA).toHaveProperty('score')
+    expect(parsed.modelB).toHaveProperty('score')
+  })
+})
+
+describe('toCompareMarkdown', () => {
+  it('produces a markdown table with both models', () => {
+    const compareResult = buildCompareResult(resultA, resultB)
+    const md = toCompareMarkdown(compareResult)
+
+    expect(md).toContain('# toolscore compare')
+    expect(md).toContain('llama3.1:8b')
+    expect(md).toContain('gpt-4o-mini')
+  })
+
+  it('includes all dimensions', () => {
+    const compareResult = buildCompareResult(resultA, resultB)
+    const md = toCompareMarkdown(compareResult)
+
+    expect(md).toContain('| selection')
+    expect(md).toContain('| args')
+    expect(md).toContain('| parallel')
+    expect(md).toContain('| refusal')
+    expect(md).toContain('| recovery')
+  })
+
+  it('marks winner with ★', () => {
+    const compareResult = buildCompareResult(resultA, resultB)
+    const md = toCompareMarkdown(compareResult)
+    expect(md).toContain('★')
+  })
+
+  it('shows winner summary', () => {
+    const compareResult = buildCompareResult(resultA, resultB)
+    const md = toCompareMarkdown(compareResult)
+    expect(md).toContain('**Winner:**')
+    expect(md).toContain('gpt-4o-mini')
+    expect(md).toContain('+24 points')
+  })
+
+  it('shows biggest gap', () => {
+    const compareResult = buildCompareResult(resultA, resultB)
+    const md = toCompareMarkdown(compareResult)
+    expect(md).toContain('**Biggest gap:**')
+    expect(md).toContain('recovery')
+  })
+
+  it('handles tie correctly', () => {
+    const compareResult = buildCompareResult(resultTieA, resultTieB)
+    const md = toCompareMarkdown(compareResult)
+    expect(md).not.toContain('**Winner:**')
+    expect(md).toContain('**Result:** Tie')
+  })
+
+  it('includes TOTAL row', () => {
+    const compareResult = buildCompareResult(resultA, resultB)
+    const md = toCompareMarkdown(compareResult)
+    expect(md).toContain('**TOTAL**')
+  })
+})

--- a/src/cli/compare.ts
+++ b/src/cli/compare.ts
@@ -1,0 +1,243 @@
+import chalk from 'chalk'
+import { runBenchmark } from '../core/runner.js'
+import { parseModel } from '../providers/index.js'
+import { VERSION } from '../version.js'
+import type { Dimension, ToolscoreResult, RunOptions } from '../types/index.js'
+
+const DIMS: Dimension[] = ['selection', 'args', 'parallel', 'refusal', 'recovery']
+
+export interface CompareOptions {
+  apiKey?: string
+  apiKeyA?: string
+  apiKeyB?: string
+  baseUrlA?: string
+  baseUrlB?: string
+  dimension?: string
+  format?: string
+}
+
+export interface CompareResult {
+  modelA: ToolscoreResult
+  modelB: ToolscoreResult
+  winner: 'modelA' | 'modelB' | 'tie'
+  totalDiff: number
+  dimensionWins: { modelA: number; modelB: number }
+}
+
+export function buildCompareResult(
+  modelA: ToolscoreResult,
+  modelB: ToolscoreResult
+): CompareResult {
+  const dimensionWins = { modelA: 0, modelB: 0 }
+
+  for (const dim of DIMS) {
+    const a = modelA.dimensions[dim]
+    const b = modelB.dimensions[dim]
+    if (!a || !b || a.total === 0) continue
+    if (a.score > b.score) dimensionWins.modelA++
+    else if (b.score > a.score) dimensionWins.modelB++
+  }
+
+  const totalDiff = Math.abs(modelA.score - modelB.score)
+  let winner: 'modelA' | 'modelB' | 'tie'
+  if (modelA.score > modelB.score) winner = 'modelA'
+  else if (modelB.score > modelA.score) winner = 'modelB'
+  else winner = 'tie'
+
+  return { modelA, modelB, winner, totalDiff, dimensionWins }
+}
+
+export function getBiggestGap(modelA: ToolscoreResult, modelB: ToolscoreResult): { dim: Dimension; gap: number } | null {
+  let biggestGap = 0
+  let biggestDim: Dimension | null = null
+
+  for (const dim of DIMS) {
+    const a = modelA.dimensions[dim]
+    const b = modelB.dimensions[dim]
+    if (!a || !b || a.total === 0) continue
+    const gap = Math.abs(a.score - b.score)
+    if (gap > biggestGap) {
+      biggestGap = gap
+      biggestDim = dim
+    }
+  }
+
+  return biggestDim ? { dim: biggestDim, gap: biggestGap } : null
+}
+
+export function toCompareJSON(result: CompareResult): string {
+  return JSON.stringify(result, null, 2)
+}
+
+export function toCompareMarkdown(result: CompareResult): string {
+  const { modelA, modelB, winner, totalDiff, dimensionWins } = result
+  const nameA = modelA.modelResolved
+  const nameB = modelB.modelResolved
+
+  const lines: string[] = []
+  lines.push(`# toolscore compare`)
+  lines.push('')
+  lines.push(`**Model A:** \`${nameA}\``)
+  lines.push(`**Model B:** \`${nameB}\``)
+  lines.push('')
+  lines.push(`| Dimension | ${nameA} | ${nameB} |`)
+  lines.push(`|-----------|${'-'.repeat(nameA.length + 2)}|${'-'.repeat(nameB.length + 2)}|`)
+
+  for (const dim of DIMS) {
+    const a = modelA.dimensions[dim]
+    const b = modelB.dimensions[dim]
+    if (!a || !b || a.total === 0) continue
+
+    const aStr = `${a.pass}/${a.total} (${a.score}%)`
+    const bStr = `${b.pass}/${b.total} (${b.score}%)`
+
+    let aCell = aStr
+    let bCell = bStr
+
+    if (a.score > b.score) aCell = `**${aStr} ★**`
+    else if (b.score > a.score) bCell = `**${bStr} ★**`
+
+    lines.push(`| ${dim} | ${aCell} | ${bCell} |`)
+  }
+
+  // Total row
+  const aTotal = `${modelA.stats.passed}/${modelA.stats.total} (${modelA.score}%)`
+  const bTotal = `${modelB.stats.passed}/${modelB.stats.total} (${modelB.score}%)`
+  let aTotalCell = `**${aTotal}**`
+  let bTotalCell = `**${bTotal}**`
+  if (winner === 'modelA') aTotalCell = `**${aTotal} ★**`
+  else if (winner === 'modelB') bTotalCell = `**${bTotal} ★**`
+
+  lines.push(`| **TOTAL** | ${aTotalCell} | ${bTotalCell} |`)
+  lines.push('')
+
+  if (winner === 'tie') {
+    lines.push(`**Result:** Tie`)
+  } else {
+    const winnerName = winner === 'modelA' ? nameA : nameB
+    lines.push(`**Winner:** ${winnerName} (+${totalDiff} points)`)
+  }
+
+  const biggestGap = getBiggestGap(modelA, modelB)
+  if (biggestGap) {
+    lines.push(`**Biggest gap:** ${biggestGap.dim} (${biggestGap.gap} point difference)`)
+  }
+
+  lines.push('')
+  lines.push(`*Dimension wins — ${nameA}: ${dimensionWins.modelA} | ${nameB}: ${dimensionWins.modelB}*`)
+
+  return lines.join('\n')
+}
+
+export function printCompareTable(result: CompareResult): void {
+  const { modelA, modelB, winner, totalDiff, dimensionWins } = result
+  const nameA = modelA.modelResolved
+  const nameB = modelB.modelResolved
+  const provA = modelA.endpoint
+  const provB = modelB.endpoint
+
+  const COL_W = 18
+  const pad = (s: string, w: number) => s.padEnd(w).slice(0, w)
+  const padl = (s: string, w: number) => s.padStart(w).slice(0, w)
+
+  const top    = `┌${'─'.repeat(COL_W)}┬${'─'.repeat(COL_W)}┬${'─'.repeat(COL_W)}┐`
+  const mid    = `├${'─'.repeat(COL_W)}┼${'─'.repeat(COL_W)}┼${'─'.repeat(COL_W)}┤`
+  const bot    = `└${'─'.repeat(COL_W)}┴${'─'.repeat(COL_W)}┴${'─'.repeat(COL_W)}┘`
+  const row = (c1: string, c2: string, c3: string) =>
+    `│${pad(c1, COL_W)}│${pad(c2, COL_W)}│${pad(c3, COL_W)}│`
+
+  const colorA = (s: string) => winner === 'modelA' ? chalk.green(s) : winner === 'modelB' ? chalk.dim(s) : s
+  const colorB = (s: string) => winner === 'modelB' ? chalk.green(s) : winner === 'modelA' ? chalk.dim(s) : s
+
+  console.log()
+  console.log(chalk.bold.white('  toolscore compare'))
+  console.log()
+  console.log(`  ${chalk.bold('Model A:')} ${chalk.cyan(nameA)}  ${chalk.gray(`(${provA})`)}`)
+  console.log(`  ${chalk.bold('Model B:')} ${chalk.cyan(nameB)}  ${chalk.gray(`(${provB})`)}`)
+  console.log()
+
+  console.log('  ' + top)
+  // Header row
+  const hDim = ' Dimension'
+  const hA = ' ' + nameA.slice(0, COL_W - 2)
+  const hB = ' ' + nameB.slice(0, COL_W - 2)
+  console.log('  ' + `│${chalk.bold(pad(hDim, COL_W))}│${colorA(chalk.bold(pad(hA, COL_W)))}│${colorB(chalk.bold(pad(hB, COL_W)))}│`)
+  console.log('  ' + mid)
+
+  for (const dim of DIMS) {
+    const a = modelA.dimensions[dim]
+    const b = modelB.dimensions[dim]
+    if (!a || !b || a.total === 0) continue
+
+    const aWins = a.score > b.score
+    const bWins = b.score > a.score
+
+    const aStr = ` ${a.pass}/${a.total} (${a.score}%)${aWins ? ' ★' : ''} `
+    const bStr = ` ${b.pass}/${b.total} (${b.score}%)${bWins ? ' ★' : ''} `
+
+    const dimCell = ` ${dim}`
+    console.log(
+      '  ' +
+      `│${pad(dimCell, COL_W)}│${colorA(pad(aStr, COL_W))}│${colorB(pad(bStr, COL_W))}│`
+    )
+  }
+
+  console.log('  ' + mid)
+
+  // Total row
+  const aWinsTotal = modelA.score > modelB.score
+  const bWinsTotal = modelB.score > modelA.score
+  const aTotalStr = ` ${modelA.stats.passed}/${modelA.stats.total} (${modelA.score}%)${aWinsTotal ? ' ★' : ''} `
+  const bTotalStr = ` ${modelB.stats.passed}/${modelB.stats.total} (${modelB.score}%)${bWinsTotal ? ' ★' : ''} `
+  console.log(
+    '  ' +
+    `│${pad(chalk.bold(' TOTAL'), COL_W)}│${colorA(chalk.bold(pad(aTotalStr, COL_W)))}│${colorB(chalk.bold(pad(bTotalStr, COL_W)))}│`
+  )
+  console.log('  ' + bot)
+  console.log()
+
+  if (winner === 'tie') {
+    console.log(`  ${chalk.bold('Result:')} Tie — both models scored ${modelA.score}`)
+  } else {
+    const winnerName = winner === 'modelA' ? nameA : nameB
+    console.log(`  ${chalk.bold('Winner:')} ${chalk.green(winnerName)} (+${totalDiff} points)`)
+  }
+
+  const biggestGap = getBiggestGap(modelA, modelB)
+  if (biggestGap) {
+    console.log(`  ${chalk.bold('Biggest gap:')} ${biggestGap.dim} (${biggestGap.gap} point difference)`)
+  }
+
+  console.log()
+}
+
+export async function runCompare(
+  modelA: string,
+  modelB: string,
+  options: CompareOptions
+): Promise<CompareResult> {
+  const dims = options.dimension
+    ? [options.dimension as Dimension]
+    : undefined
+
+  const runOptionsA: RunOptions = {
+    model: modelA,
+    apiKey: options.apiKeyA ?? options.apiKey,
+    baseUrl: options.baseUrlA,
+    dimensions: dims,
+  }
+
+  const runOptionsB: RunOptions = {
+    model: modelB,
+    apiKey: options.apiKeyB ?? options.apiKey,
+    baseUrl: options.baseUrlB,
+    dimensions: dims,
+  }
+
+  const [resultA, resultB] = await Promise.all([
+    runBenchmark(runOptionsA),
+    runBenchmark(runOptionsB),
+  ])
+
+  return buildCompareResult(resultA, resultB)
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { getCaseCounts, getAllCases } from '../cases/index.js'
 import { parseModel } from '../providers/index.js'
 import type { Dimension, RunOptions } from '../types/index.js'
 import { VERSION } from '../version.js'
+import { runCompare, printCompareTable, toCompareJSON, toCompareMarkdown } from './compare.js'
 import fs from 'fs'
 import path from 'path'
 
@@ -249,5 +250,63 @@ function printDryRun(options: RunOptions): void {
 
   console.log()
 }
+
+program
+  .command('compare <model-a> <model-b>')
+  .description('Compare two models side-by-side')
+  .option('-k, --api-key <key>', 'API key for both models')
+  .option('--api-key-a <key>', 'API key for model A')
+  .option('--api-key-b <key>', 'API key for model B')
+  .option('--base-url-a <url>', 'Base URL for model A')
+  .option('--base-url-b <url>', 'Base URL for model B')
+  .option('-d, --dimension <dim>', 'Run only this dimension')
+  .option('-f, --format <fmt>', 'Output format: terminal (default), json, markdown')
+  .action(async (modelA: string, modelB: string, options) => {
+    console.log()
+    console.log(
+      chalk.bold.white('  toolscore compare') +
+      chalk.gray(' v' + VERSION)
+    )
+    console.log()
+    console.log(`  ${chalk.bold('Model A:')} ${chalk.cyan(modelA)}`)
+    console.log(`  ${chalk.bold('Model B:')} ${chalk.cyan(modelB)}`)
+    console.log()
+
+    const spinner = ora({
+      text: 'Running benchmarks concurrently...',
+      prefixText: '  ',
+      color: 'cyan',
+    }).start()
+
+    try {
+      const result = await runCompare(modelA, modelB, {
+        apiKey: options.apiKey,
+        apiKeyA: options.apiKeyA,
+        apiKeyB: options.apiKeyB,
+        baseUrlA: options.baseUrlA,
+        baseUrlB: options.baseUrlB,
+        dimension: options.dimension,
+        format: options.format,
+      })
+
+      spinner.stop()
+
+      const format = options.format ?? 'terminal'
+      if (format === 'json') {
+        console.log(toCompareJSON(result))
+      } else if (format === 'markdown') {
+        console.log(toCompareMarkdown(result))
+      } else {
+        printCompareTable(result)
+      }
+    } catch (err) {
+      spinner.stop()
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error()
+      console.error(chalk.red(`  Error: ${msg}`))
+      console.error()
+      process.exit(1)
+    }
+  })
 
 program.parse()


### PR DESCRIPTION
Adds `toolscore compare model-a model-b` subcommand.

## What
- Runs benchmark concurrently against two models
- Side-by-side terminal table with ★ winner highlight
- `--format json` and `--format markdown` supported
- Tests covering comparison logic, winner detection, gap calculation

Closes #8