### PR TITLE
feat(cli): badge generator — embeddable shields.io badges (closes #10)

### DIFF
--- a/src/cli/__tests__/badge.test.ts
+++ b/src/cli/__tests__/badge.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect } from 'vitest'
+import { getBadgeColor, generateBadgeUrl, formatBadgeOutput } from '../badge.js'
+
+describe('getBadgeColor', () => {
+  test('returns brightgreen for score >= 90', () => {
+    expect(getBadgeColor(90)).toBe('brightgreen')
+    expect(getBadgeColor(100)).toBe('brightgreen')
+    expect(getBadgeColor(95)).toBe('brightgreen')
+  })
+
+  test('returns green for score >= 75 and < 90', () => {
+    expect(getBadgeColor(75)).toBe('green')
+    expect(getBadgeColor(89)).toBe('green')
+    expect(getBadgeColor(80)).toBe('green')
+  })
+
+  test('returns yellow for score >= 60 and < 75', () => {
+    expect(getBadgeColor(60)).toBe('yellow')
+    expect(getBadgeColor(74)).toBe('yellow')
+    expect(getBadgeColor(67)).toBe('yellow')
+  })
+
+  test('returns orange for score >= 40 and < 60', () => {
+    expect(getBadgeColor(40)).toBe('orange')
+    expect(getBadgeColor(59)).toBe('orange')
+    expect(getBadgeColor(50)).toBe('orange')
+  })
+
+  test('returns red for score < 40', () => {
+    expect(getBadgeColor(39)).toBe('red')
+    expect(getBadgeColor(0)).toBe('red')
+    expect(getBadgeColor(1)).toBe('red')
+  })
+
+  test('boundary: exactly 90 is brightgreen not green', () => {
+    expect(getBadgeColor(90)).toBe('brightgreen')
+  })
+
+  test('boundary: exactly 75 is green not yellow', () => {
+    expect(getBadgeColor(75)).toBe('green')
+  })
+
+  test('boundary: exactly 60 is yellow not orange', () => {
+    expect(getBadgeColor(60)).toBe('yellow')
+  })
+
+  test('boundary: exactly 40 is orange not red', () => {
+    expect(getBadgeColor(40)).toBe('orange')
+  })
+})
+
+describe('generateBadgeUrl', () => {
+  test('uses %25 encoding for percent sign', () => {
+    const url = generateBadgeUrl(87)
+    expect(url).toContain('87%25')
+    expect(url).not.toMatch(/87%(?!25)/)
+  })
+
+  test('includes shields.io base URL', () => {
+    const url = generateBadgeUrl(50)
+    expect(url).toMatch(/^https:\/\/img\.shields\.io\/badge\/toolscore-/)
+  })
+
+  test('includes correct color for score 87 (brightgreen)', () => {
+    const url = generateBadgeUrl(92)
+    expect(url).toContain('brightgreen')
+  })
+
+  test('includes correct color for score 80 (green)', () => {
+    const url = generateBadgeUrl(80)
+    expect(url).toContain('green')
+    expect(url).not.toContain('brightgreen')
+  })
+
+  test('includes correct color for score 65 (yellow)', () => {
+    const url = generateBadgeUrl(65)
+    expect(url).toContain('yellow')
+  })
+
+  test('full URL format for score 87', () => {
+    expect(generateBadgeUrl(87)).toBe(
+      'https://img.shields.io/badge/toolscore-87%25-green'
+    )
+  })
+
+  test('full URL format for score 100', () => {
+    expect(generateBadgeUrl(100)).toBe(
+      'https://img.shields.io/badge/toolscore-100%25-brightgreen'
+    )
+  })
+
+  test('full URL format for score 0', () => {
+    expect(generateBadgeUrl(0)).toBe(
+      'https://img.shields.io/badge/toolscore-0%25-red'
+    )
+  })
+})
+
+describe('formatBadgeOutput', () => {
+  test('contains markdown badge syntax', () => {
+    const output = formatBadgeOutput(87)
+    expect(output).toContain('![toolscore: 87%]')
+  })
+
+  test('contains Shields.io URL label', () => {
+    const output = formatBadgeOutput(87)
+    expect(output).toContain('Shields.io URL:')
+  })
+
+  test('contains HTML img tag', () => {
+    const output = formatBadgeOutput(87)
+    expect(output).toContain('<img src=')
+    expect(output).toContain('alt="toolscore: 87%"')
+  })
+
+  test('contains README copy instruction', () => {
+    const output = formatBadgeOutput(87)
+    expect(output).toContain('Badge (copy to your README):')
+  })
+
+  test('HTML tag uses correct URL', () => {
+    const output = formatBadgeOutput(75)
+    const url = generateBadgeUrl(75)
+    expect(output).toContain(`<img src="${url}"`)
+  })
+
+  test('markdown badge uses correct URL', () => {
+    const output = formatBadgeOutput(75)
+    const url = generateBadgeUrl(75)
+    expect(output).toContain(`![toolscore: 75%](${url})`)
+  })
+
+  test('score 0 uses red color in output', () => {
+    const output = formatBadgeOutput(0)
+    expect(output).toContain('red')
+  })
+
+  test('score 100 uses brightgreen color in output', () => {
+    const output = formatBadgeOutput(100)
+    expect(output).toContain('brightgreen')
+  })
+})

--- a/src/cli/badge.ts
+++ b/src/cli/badge.ts
@@ -1,0 +1,31 @@
+/**
+ * Badge generator for toolscore — embeddable shields.io badges
+ */
+
+export function getBadgeColor(score: number): string {
+  if (score >= 90) return 'brightgreen'
+  if (score >= 75) return 'green'
+  if (score >= 60) return 'yellow'
+  if (score >= 40) return 'orange'
+  return 'red'
+}
+
+export function generateBadgeUrl(score: number): string {
+  const color = getBadgeColor(score)
+  // %25 is the percent-encoded form of '%', so the badge shows "87%"
+  return `https://img.shields.io/badge/toolscore-${score}%25-${color}`
+}
+
+export function formatBadgeOutput(score: number): string {
+  const url = generateBadgeUrl(score)
+  return [
+    'Badge (copy to your README):',
+    `![toolscore: ${score}%](${url})`,
+    '',
+    'Shields.io URL:',
+    url,
+    '',
+    'HTML:',
+    `<img src="${url}" alt="toolscore: ${score}%">`,
+  ].join('\n')
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { getCaseCounts, getAllCases } from '../cases/index.js'
 import { parseModel } from '../providers/index.js'
 import type { Dimension, RunOptions } from '../types/index.js'
 import { VERSION } from '../version.js'
+import { formatBadgeOutput } from './badge.js'
 import fs from 'fs'
 import path from 'path'
 
@@ -31,6 +32,7 @@ program
   .option('--list-cases', 'List test case counts per dimension')
   .option('--verbose', 'Show per-case results')
   .option('--fail-below <score>', 'Exit with code 1 if score is below this threshold', parseInt)
+  .option('--badge', 'Print embeddable shields.io badge info after the run')
 
 program.action(async (options) => {
   // List cases mode
@@ -170,6 +172,13 @@ program.action(async (options) => {
         console.log(chalk.gray(`  Saved: ${filename}`))
         console.log()
       }
+    }
+
+    // Print badge info if --badge flag is set
+    if (options.badge) {
+      console.log()
+      console.log(formatBadgeOutput(result.score))
+      console.log()
     }
 
     // Check threshold


### PR DESCRIPTION
## Summary

Adds a `--badge` flag to the toolscore CLI that prints embeddable shields.io badge info after a successful run.

## Files Created

- **`src/cli/badge.ts`** — core badge module with:
  - `getBadgeColor(score)` — maps score to shields.io color
  - `generateBadgeUrl(score)` — builds shields.io URL with `%25` percent-encoding
  - `formatBadgeOutput(score)` — full multi-line badge block (markdown, URL, HTML)
- **`src/cli/__tests__/badge.test.ts`** — 25 tests covering all color thresholds at boundaries, URL encoding, and output format

## Files Modified

- **`src/cli/index.ts`** — imports `formatBadgeOutput`, adds `--badge` boolean flag, prints badge block after successful run

## Tests

✅ **25 / 25 tests passing**

## Usage

```
toolscore --model openai/gpt-4o --badge
```

Output appended after normal run:

```
Badge (copy to your README):
![toolscore: 87%](https://img.shields.io/badge/toolscore-87%25-green)

Shields.io URL:
https://img.shields.io/badge/toolscore-87%25-green

HTML:
<img src="https://img.shields.io/badge/toolscore-87%25-green" alt="toolscore: 87%">
```

## Color Coding

| Score | Color |
|-------|-------|
| >= 90% | `brightgreen` |
| >= 75% | `green` |
| >= 60% | `yellow` |
| >= 40% | `orange` |
| < 40% | `red` |