### PR TITLE
feat(cli): --pack flag — benchmark with custom tool schemas (closes #9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -886,15 +886,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.0.tgz",
+      "integrity": "sha512-N3/xR4fSu0+6sVZETEtPT1orUs2+Y477JOXTcU3xKuu3uBlsgbD7/7Mz2LZ1Jr1XjwilEWlrIgSCj4N1+5ZmsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
+        "@vitest/spy": "2.1.0",
+        "@vitest/utils": "2.1.0",
+        "chai": "^5.1.1",
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
@@ -902,21 +902,22 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.0.tgz",
+      "integrity": "sha512-ZxENovUqhzl+QiOFpagiHUNUuZ1qPd5yYTCYHomGIZOFArzn4mgX2oxZmiAItJWAaXHG6bbpb/DpSPhlk5DgtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.9",
+        "@vitest/spy": "^2.1.0-beta.1",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.12"
+        "magic-string": "^0.30.11"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "msw": "^2.4.9",
+        "@vitest/spy": "2.1.0",
+        "msw": "^2.3.5",
         "vite": "^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -942,13 +943,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.0.tgz",
+      "integrity": "sha512-D9+ZiB8MbMt7qWDRJc4CRNNUlne/8E1X7dcKhZVAbcOKG58MGGYVDqAq19xlhNfMFZsW0bpVKgztBwks38Ko0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.9",
+        "@vitest/utils": "2.1.0",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -963,15 +964,28 @@
       "license": "MIT"
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.0.tgz",
+      "integrity": "sha512-x69CygGMzt9VCO283K2/FYQ+nBrOj66OTKpsPykjCR4Ac3lLV+m85hj9reaIGmjBSsKzVvbxWmjWE3kF5ha3uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "magic-string": "^0.30.12",
+        "@vitest/pretty-format": "2.1.0",
+        "magic-string": "^0.30.11",
         "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.0.tgz",
+      "integrity": "sha512-7sxf2F3DNYatgmzXXcTh6cq+/fxwB47RIQqZJFoSH883wnVAoccSRT6g+dTKemUBo8Q5N4OYYj1EBXLuRKvp3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -985,27 +999,40 @@
       "license": "MIT"
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.0.tgz",
+      "integrity": "sha512-IXX5NkbdgTYTog3F14i2LgnBc+20YmkXMx0IWai84mcxySUDRgm0ihbOfR4L0EVRBDFG85GjmQQEZNNKVVpkZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-rreyfVe0PuNqJfKYUwfPDfi6rrp0VSu0Wgvp5WBqJonP+4NvXHk48X6oBam1Lj47Hy6jbJtnMj3OcRdrkTP0tA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
+        "@vitest/pretty-format": "2.1.0",
+        "loupe": "^3.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.0.tgz",
+      "integrity": "sha512-7sxf2F3DNYatgmzXXcTh6cq+/fxwB47RIQqZJFoSH883wnVAoccSRT6g+dTKemUBo8Q5N4OYYj1EBXLuRKvp3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
@@ -1318,13 +1345,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1411,16 +1431,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2549,15 +2559,14 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.0.tgz",
+      "integrity": "sha512-+ybYqBVUjYyIscoLzMWodus2enQDZOpGhcU6HdOVD6n8WZdk12w1GFL3mbnxLs7hPtRtqs1Wo5YF6/Tsr6fmhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.7",
-        "es-module-lexer": "^1.5.4",
+        "debug": "^4.3.6",
         "pathe": "^1.1.2",
         "vite": "^5.0.0"
       },
@@ -3009,31 +3018,30 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.0.tgz",
+      "integrity": "sha512-XuuEeyNkqbfr0FtAvd9vFbInSSNY1ykCQTYQ0sj9wPy4hx+1gR7gqVNdW0AX2wrrM1wWlN5fnJDjF9xG6mYRSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.9",
-        "@vitest/mocker": "2.1.9",
-        "@vitest/pretty-format": "^2.1.9",
-        "@vitest/runner": "2.1.9",
-        "@vitest/snapshot": "2.1.9",
-        "@vitest/spy": "2.1.9",
-        "@vitest/utils": "2.1.9",
-        "chai": "^5.1.2",
-        "debug": "^4.3.7",
-        "expect-type": "^1.1.0",
-        "magic-string": "^0.30.12",
+        "@vitest/expect": "2.1.0",
+        "@vitest/mocker": "2.1.0",
+        "@vitest/pretty-format": "^2.1.0",
+        "@vitest/runner": "2.1.0",
+        "@vitest/snapshot": "2.1.0",
+        "@vitest/spy": "2.1.0",
+        "@vitest/utils": "2.1.0",
+        "chai": "^5.1.1",
+        "debug": "^4.3.6",
+        "magic-string": "^0.30.11",
         "pathe": "^1.1.2",
-        "std-env": "^3.8.0",
+        "std-env": "^3.7.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.1",
-        "tinypool": "^1.0.1",
+        "tinyexec": "^0.3.0",
+        "tinypool": "^1.0.0",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.1.9",
+        "vite-node": "2.1.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -3048,8 +3056,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.9",
-        "@vitest/ui": "2.1.9",
+        "@vitest/browser": "2.1.0",
+        "@vitest/ui": "2.1.0",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { getCaseCounts, getAllCases } from '../cases/index.js'
 import { parseModel } from '../providers/index.js'
 import type { Dimension, RunOptions } from '../types/index.js'
 import { VERSION } from '../version.js'
+import { loadPack, packCasesToTestCases } from '../core/pack.js'
 import fs from 'fs'
 import path from 'path'
 
@@ -31,6 +32,7 @@ program
   .option('--list-cases', 'List test case counts per dimension')
   .option('--verbose', 'Show per-case results')
   .option('--fail-below <score>', 'Exit with code 1 if score is below this threshold', parseInt)
+  .option('--pack <path>', 'Benchmark using a custom pack JSON file instead of the built-in suite')
 
 program.action(async (options) => {
   // List cases mode
@@ -55,6 +57,21 @@ program.action(async (options) => {
     ? [options.dimension as Dimension]
     : undefined
 
+  // Load custom pack if --pack is set
+  let packTestCases: import('../types/index.js').TestCase[] | undefined
+  if (options.pack) {
+    try {
+      const pack = loadPack(options.pack)
+      packTestCases = packCasesToTestCases(pack, dims)
+      console.log()
+      console.log(chalk.cyan(`  Pack: ${pack.name}`) + chalk.gray(` (v${pack.version})  —  ${packTestCases.length} cases`))
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(chalk.red(`  Error loading pack: ${msg}`))
+      process.exit(1)
+    }
+  }
+
   const runOptions: RunOptions = {
     model: options.model,
     apiKey: options.apiKey,
@@ -65,6 +82,7 @@ program.action(async (options) => {
     concurrency: options.concurrency ?? 3,
     dryRun: options.dryRun,
     verbose: options.verbose,
+    customCases: packTestCases,
   }
 
   // Dry run mode
@@ -222,11 +240,15 @@ function printCaseList(): void {
 
 function printDryRun(options: RunOptions): void {
   const config = parseModel(options.model, { apiKey: options.apiKey, baseUrl: options.baseUrl })
-  const cases = getAllCases()
 
-  const dims = options.dimensions
-    ? cases.filter(c => options.dimensions!.includes(c.dimension as Dimension))
-    : cases
+  // Use custom cases from --pack if provided
+  const allCases = options.customCases ?? getAllCases()
+
+  const dims = options.customCases
+    ? allCases  // already filtered by packCasesToTestCases
+    : (options.dimensions
+        ? allCases.filter(c => options.dimensions!.includes(c.dimension as Dimension))
+        : allCases)
 
   console.log()
   console.log(chalk.bold.white('  toolscore dry-run'))

--- a/src/core/__tests__/pack.test.ts
+++ b/src/core/__tests__/pack.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { validatePack, loadPack, packCasesToTestCases } from '../pack.js'
+import type { Pack } from '../pack.js'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+const validTool = {
+  name: 'create_event',
+  description: 'Create a calendar event',
+  parameters: {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      datetime: { type: 'string' },
+    },
+    required: ['title', 'datetime'],
+  },
+}
+
+const validCase = {
+  id: 'cal_001',
+  dimension: 'selection',
+  prompt: 'Schedule a meeting next Tuesday at 3pm',
+  tools: [validTool],
+  expected: {
+    calls: [{ name: 'create_event' }],
+  },
+}
+
+const validPack = {
+  version: '1',
+  name: 'calendar-tools',
+  cases: [validCase],
+}
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'toolscore-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function writePack(name: string, content: string): string {
+  const filePath = path.join(tmpDir, name)
+  fs.writeFileSync(filePath, content, 'utf8')
+  return filePath
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// validatePack — valid pack
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('validatePack', () => {
+  it('accepts a valid pack', () => {
+    const result = validatePack(validPack)
+    expect(result.version).toBe('1')
+    expect(result.name).toBe('calendar-tools')
+    expect(result.cases).toHaveLength(1)
+    expect(result.cases[0].id).toBe('cal_001')
+  })
+
+  it('accepts all valid dimensions', () => {
+    const dims = ['selection', 'args', 'parallel', 'refusal', 'recovery']
+    for (const dim of dims) {
+      const pack = {
+        ...validPack,
+        cases: [{ ...validCase, id: `case_${dim}`, dimension: dim }],
+      }
+      const result = validatePack(pack)
+      expect(result.cases[0].dimension).toBe(dim)
+    }
+  })
+
+  it('accepts empty cases array', () => {
+    const pack = { ...validPack, cases: [] }
+    const result = validatePack(pack)
+    expect(result.cases).toHaveLength(0)
+  })
+
+  it('accepts a case with noCall expected', () => {
+    const pack = {
+      ...validPack,
+      cases: [{ ...validCase, expected: { noCall: true } }],
+    }
+    const result = validatePack(pack)
+    expect(result.cases[0].expected).toEqual({ noCall: true })
+  })
+
+  it('accepts optional fields: system, difficulty, tags', () => {
+    const pack = {
+      ...validPack,
+      cases: [{
+        ...validCase,
+        system: 'You are a calendar assistant',
+        difficulty: 'easy',
+        tags: ['calendar', 'scheduling'],
+      }],
+    }
+    const result = validatePack(pack)
+    expect(result.cases[0].system).toBe('You are a calendar assistant')
+    expect(result.cases[0].difficulty).toBe('easy')
+    expect(result.cases[0].tags).toEqual(['calendar', 'scheduling'])
+  })
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Missing top-level fields
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('throws when version is missing', () => {
+    const { version: _v, ...pack } = validPack
+    expect(() => validatePack(pack)).toThrow(/"version"/)
+  })
+
+  it('throws when name is missing', () => {
+    const { name: _n, ...pack } = validPack
+    expect(() => validatePack(pack)).toThrow(/"name"/)
+  })
+
+  it('throws when cases is missing', () => {
+    const { cases: _c, ...pack } = validPack
+    expect(() => validatePack(pack)).toThrow(/"cases"/)
+  })
+
+  it('throws when the root is not an object', () => {
+    expect(() => validatePack('not an object')).toThrow(/JSON object/)
+    expect(() => validatePack(null)).toThrow(/JSON object/)
+    expect(() => validatePack([validPack])).toThrow(/JSON object/)
+  })
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Invalid dimension
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('throws on invalid dimension value', () => {
+    const pack = {
+      ...validPack,
+      cases: [{ ...validCase, dimension: 'unknown_dim' }],
+    }
+    expect(() => validatePack(pack)).toThrow(/invalid dimension/)
+  })
+
+  it('error message for invalid dimension lists valid options', () => {
+    const pack = {
+      ...validPack,
+      cases: [{ ...validCase, dimension: 'bad' }],
+    }
+    try {
+      validatePack(pack)
+      expect.fail('should have thrown')
+    } catch (err) {
+      const msg = (err as Error).message
+      expect(msg).toContain('selection')
+      expect(msg).toContain('args')
+      expect(msg).toContain('parallel')
+      expect(msg).toContain('refusal')
+      expect(msg).toContain('recovery')
+    }
+  })
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Missing case fields
+  // ────────────────────────────────────────────────────────────────────────
+
+  it('throws when case is missing id', () => {
+    const { id: _id, ...caseNoId } = validCase
+    expect(() => validatePack({ ...validPack, cases: [caseNoId] })).toThrow(/"id"/)
+  })
+
+  it('throws when case is missing prompt', () => {
+    const { prompt: _p, ...caseNoPrompt } = validCase
+    expect(() => validatePack({ ...validPack, cases: [caseNoPrompt] })).toThrow(/"prompt"/)
+  })
+
+  it('throws when case is missing tools', () => {
+    const { tools: _t, ...caseNoTools } = validCase
+    expect(() => validatePack({ ...validPack, cases: [caseNoTools] })).toThrow(/"tools"/)
+  })
+
+  it('throws when case tools array is empty', () => {
+    const pack = { ...validPack, cases: [{ ...validCase, tools: [] }] }
+    expect(() => validatePack(pack)).toThrow(/empty/)
+  })
+
+  it('throws when case expected is missing', () => {
+    const { expected: _e, ...caseNoExpected } = validCase
+    expect(() => validatePack({ ...validPack, cases: [caseNoExpected] })).toThrow(/"expected"/)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// loadPack
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('loadPack', () => {
+  it('loads a valid pack JSON file', () => {
+    const filePath = writePack('valid.json', JSON.stringify(validPack, null, 2))
+    const result = loadPack(filePath)
+    expect(result.name).toBe('calendar-tools')
+    expect(result.cases).toHaveLength(1)
+  })
+
+  it('throws when file does not exist', () => {
+    expect(() => loadPack(path.join(tmpDir, 'nonexistent.json'))).toThrow(/not found/)
+  })
+
+  it('throws on invalid JSON', () => {
+    const filePath = writePack('bad.json', '{ "version": "1", bad json }')
+    expect(() => loadPack(filePath)).toThrow(/Invalid JSON/)
+  })
+
+  it('throws with helpful error for invalid pack structure', () => {
+    const filePath = writePack('missing-name.json', JSON.stringify({ version: '1', cases: [] }))
+    expect(() => loadPack(filePath)).toThrow(/Invalid pack file/)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// packCasesToTestCases — dimension filtering
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('packCasesToTestCases', () => {
+  const multiDimPack: Pack = {
+    version: '1',
+    name: 'multi-dim',
+    cases: [
+      { ...validCase, id: 'sel_001', dimension: 'selection' },
+      { ...validCase, id: 'args_001', dimension: 'args' },
+      { ...validCase, id: 'par_001', dimension: 'parallel' },
+      { ...validCase, id: 'ref_001', dimension: 'refusal' },
+      { ...validCase, id: 'rec_001', dimension: 'recovery' },
+    ],
+  }
+
+  it('returns all cases when no dimensions filter', () => {
+    const testCases = packCasesToTestCases(multiDimPack)
+    expect(testCases).toHaveLength(5)
+  })
+
+  it('filters to a single dimension', () => {
+    const testCases = packCasesToTestCases(multiDimPack, ['selection'])
+    expect(testCases).toHaveLength(1)
+    expect(testCases[0].id).toBe('sel_001')
+  })
+
+  it('filters to multiple dimensions', () => {
+    const testCases = packCasesToTestCases(multiDimPack, ['args', 'parallel'])
+    expect(testCases).toHaveLength(2)
+    const ids = testCases.map(c => c.id)
+    expect(ids).toContain('args_001')
+    expect(ids).toContain('par_001')
+  })
+
+  it('returns empty array when no cases match the dimension filter', () => {
+    const singleDimPack: Pack = {
+      version: '1',
+      name: 'single',
+      cases: [{ ...validCase, dimension: 'selection' }],
+    }
+    const testCases = packCasesToTestCases(singleDimPack, ['refusal'])
+    expect(testCases).toHaveLength(0)
+  })
+
+  it('converts pack tools to TestCase tool format with type:function wrapper', () => {
+    const testCases = packCasesToTestCases({ ...validPack, cases: [validCase] })
+    expect(testCases[0].tools[0]).toHaveProperty('type', 'function')
+    expect(testCases[0].tools[0]).toHaveProperty('function')
+    expect((testCases[0].tools[0] as any).function.name).toBe('create_event')
+  })
+
+  it('converts expected calls with argsMatchMode subset default', () => {
+    const testCases = packCasesToTestCases(validPack)
+    const expected = testCases[0].expected as { calls: any[] }
+    expect(expected.calls[0].argsMatchMode).toBe('subset')
+  })
+
+  it('preserves noCall expected cases', () => {
+    const pack: Pack = {
+      version: '1',
+      name: 'noCall-test',
+      cases: [{ ...validCase, expected: { noCall: true } }],
+    }
+    const testCases = packCasesToTestCases(pack)
+    expect(testCases[0].expected).toEqual({ noCall: true })
+  })
+
+  it('handles empty cases array', () => {
+    const emptyPack: Pack = { version: '1', name: 'empty', cases: [] }
+    const testCases = packCasesToTestCases(emptyPack)
+    expect(testCases).toHaveLength(0)
+  })
+})

--- a/src/core/pack.ts
+++ b/src/core/pack.ts
@@ -1,0 +1,359 @@
+import fs from 'fs'
+import path from 'path'
+import type { TestCase, Dimension } from '../types/index.js'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Pack Interfaces
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface PackToolParam {
+  type: string
+  description?: string
+  enum?: string[]
+  items?: unknown
+  properties?: Record<string, PackToolParam>
+  required?: string[]
+}
+
+export interface PackTool {
+  name: string
+  description: string
+  parameters: {
+    type: 'object'
+    properties: Record<string, PackToolParam>
+    required?: string[]
+  }
+}
+
+export interface PackExpectedCall {
+  name: string
+  args?: Record<string, unknown>
+}
+
+export interface PackCase {
+  id: string
+  dimension: Dimension
+  prompt: string
+  tools: PackTool[]
+  expected: {
+    calls?: PackExpectedCall[]
+    noCall?: boolean
+  }
+  system?: string
+  difficulty?: 'easy' | 'medium' | 'hard'
+  tags?: string[]
+}
+
+export interface Pack {
+  version: string
+  name: string
+  cases: PackCase[]
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Valid dimensions
+// ────────────────────────────────────────────────────────────────────────────
+
+const VALID_DIMENSIONS: Dimension[] = ['selection', 'args', 'parallel', 'refusal', 'recovery']
+
+// ────────────────────────────────────────────────────────────────────────────
+// Validation
+// ────────────────────────────────────────────────────────────────────────────
+
+export function validatePack(data: unknown): Pack {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error('Pack must be a JSON object')
+  }
+
+  const obj = data as Record<string, unknown>
+
+  // Validate version
+  if (!('version' in obj)) {
+    throw new Error('Pack is missing required field: "version"')
+  }
+  if (typeof obj.version !== 'string') {
+    throw new Error(`Pack "version" must be a string, got: ${typeof obj.version}`)
+  }
+
+  // Validate name
+  if (!('name' in obj)) {
+    throw new Error('Pack is missing required field: "name"')
+  }
+  if (typeof obj.name !== 'string') {
+    throw new Error(`Pack "name" must be a string, got: ${typeof obj.name}`)
+  }
+  if (obj.name.trim() === '') {
+    throw new Error('Pack "name" must not be empty')
+  }
+
+  // Validate cases
+  if (!('cases' in obj)) {
+    throw new Error('Pack is missing required field: "cases"')
+  }
+  if (!Array.isArray(obj.cases)) {
+    throw new Error(`Pack "cases" must be an array, got: ${typeof obj.cases}`)
+  }
+
+  const validatedCases: PackCase[] = obj.cases.map((c: unknown, index: number) => {
+    return validateCase(c, index)
+  })
+
+  return {
+    version: obj.version,
+    name: obj.name,
+    cases: validatedCases,
+  }
+}
+
+function validateCase(data: unknown, index: number): PackCase {
+  const prefix = `cases[${index}]`
+
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error(`${prefix}: must be an object`)
+  }
+
+  const c = data as Record<string, unknown>
+
+  // id
+  if (!('id' in c) || typeof c.id !== 'string' || c.id.trim() === '') {
+    throw new Error(`${prefix}: missing or invalid "id" (must be a non-empty string)`)
+  }
+
+  // dimension
+  if (!('dimension' in c)) {
+    throw new Error(`${prefix} (id: "${c.id}"): missing required field "dimension"`)
+  }
+  if (!VALID_DIMENSIONS.includes(c.dimension as Dimension)) {
+    throw new Error(
+      `${prefix} (id: "${c.id}"): invalid dimension "${c.dimension}". ` +
+      `Must be one of: ${VALID_DIMENSIONS.join(', ')}`
+    )
+  }
+
+  // prompt
+  if (!('prompt' in c) || typeof c.prompt !== 'string' || c.prompt.trim() === '') {
+    throw new Error(`${prefix} (id: "${c.id}"): missing or invalid "prompt" (must be a non-empty string)`)
+  }
+
+  // tools
+  if (!('tools' in c) || !Array.isArray(c.tools)) {
+    throw new Error(`${prefix} (id: "${c.id}"): missing or invalid "tools" (must be an array)`)
+  }
+  if (c.tools.length === 0) {
+    throw new Error(`${prefix} (id: "${c.id}"): "tools" array must not be empty`)
+  }
+
+  const validatedTools = c.tools.map((t: unknown, ti: number) => {
+    return validateTool(t, `${prefix}.tools[${ti}]`, String(c.id))
+  })
+
+  // expected
+  if (!('expected' in c) || typeof c.expected !== 'object' || c.expected === null) {
+    throw new Error(`${prefix} (id: "${c.id}"): missing or invalid "expected" (must be an object)`)
+  }
+
+  const expected = c.expected as Record<string, unknown>
+
+  if (!('calls' in expected) && !('noCall' in expected)) {
+    throw new Error(`${prefix} (id: "${c.id}"): "expected" must have either "calls" or "noCall"`)
+  }
+
+  let validatedExpected: PackCase['expected']
+
+  if ('noCall' in expected) {
+    if (expected.noCall !== true) {
+      throw new Error(`${prefix} (id: "${c.id}"): "expected.noCall" must be true`)
+    }
+    validatedExpected = { noCall: true }
+  } else {
+    if (!Array.isArray(expected.calls)) {
+      throw new Error(`${prefix} (id: "${c.id}"): "expected.calls" must be an array`)
+    }
+    const validatedCalls = expected.calls.map((call: unknown, ci: number) => {
+      return validateExpectedCall(call, `${prefix}.expected.calls[${ci}]`, String(c.id))
+    })
+    validatedExpected = { calls: validatedCalls }
+  }
+
+  // Optional fields
+  const result: PackCase = {
+    id: c.id as string,
+    dimension: c.dimension as Dimension,
+    prompt: c.prompt as string,
+    tools: validatedTools,
+    expected: validatedExpected,
+  }
+
+  if ('system' in c && c.system !== undefined) {
+    if (typeof c.system !== 'string') {
+      throw new Error(`${prefix} (id: "${c.id}"): "system" must be a string`)
+    }
+    result.system = c.system
+  }
+
+  if ('difficulty' in c && c.difficulty !== undefined) {
+    if (!['easy', 'medium', 'hard'].includes(c.difficulty as string)) {
+      throw new Error(`${prefix} (id: "${c.id}"): "difficulty" must be one of: easy, medium, hard`)
+    }
+    result.difficulty = c.difficulty as 'easy' | 'medium' | 'hard'
+  }
+
+  if ('tags' in c && c.tags !== undefined) {
+    if (!Array.isArray(c.tags) || !c.tags.every((t: unknown) => typeof t === 'string')) {
+      throw new Error(`${prefix} (id: "${c.id}"): "tags" must be an array of strings`)
+    }
+    result.tags = c.tags as string[]
+  }
+
+  return result
+}
+
+function validateTool(data: unknown, prefix: string, caseId: string): PackTool {
+  if (typeof data !== 'object' || data === null) {
+    throw new Error(`${prefix} (case: "${caseId}"): tool must be an object`)
+  }
+
+  const t = data as Record<string, unknown>
+
+  if (!('name' in t) || typeof t.name !== 'string' || t.name.trim() === '') {
+    throw new Error(`${prefix} (case: "${caseId}"): tool missing or invalid "name"`)
+  }
+
+  if (!('description' in t) || typeof t.description !== 'string') {
+    throw new Error(`${prefix} (case: "${caseId}"): tool "${t.name}" missing or invalid "description"`)
+  }
+
+  if (!('parameters' in t) || typeof t.parameters !== 'object' || t.parameters === null) {
+    throw new Error(`${prefix} (case: "${caseId}"): tool "${t.name}" missing or invalid "parameters"`)
+  }
+
+  const params = t.parameters as Record<string, unknown>
+  if (params.type !== 'object') {
+    throw new Error(`${prefix} (case: "${caseId}"): tool "${t.name}" parameters.type must be "object"`)
+  }
+
+  if (!('properties' in params) || typeof params.properties !== 'object' || params.properties === null) {
+    throw new Error(`${prefix} (case: "${caseId}"): tool "${t.name}" missing "parameters.properties"`)
+  }
+
+  return {
+    name: t.name as string,
+    description: t.description as string,
+    parameters: {
+      type: 'object',
+      properties: params.properties as Record<string, PackToolParam>,
+      required: Array.isArray(params.required) ? params.required as string[] : undefined,
+    },
+  }
+}
+
+function validateExpectedCall(data: unknown, prefix: string, caseId: string): PackExpectedCall {
+  if (typeof data !== 'object' || data === null) {
+    throw new Error(`${prefix} (case: "${caseId}"): expected call must be an object`)
+  }
+
+  const call = data as Record<string, unknown>
+
+  if (!('name' in call) || typeof call.name !== 'string' || call.name.trim() === '') {
+    throw new Error(`${prefix} (case: "${caseId}"): expected call missing or invalid "name"`)
+  }
+
+  const result: PackExpectedCall = { name: call.name as string }
+
+  if ('args' in call && call.args !== undefined) {
+    if (typeof call.args !== 'object' || Array.isArray(call.args)) {
+      throw new Error(`${prefix} (case: "${caseId}"): expected call "args" must be an object`)
+    }
+    result.args = call.args as Record<string, unknown>
+  }
+
+  return result
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Load Pack from File
+// ────────────────────────────────────────────────────────────────────────────
+
+export function loadPack(filePath: string): Pack {
+  const resolvedPath = path.resolve(filePath)
+
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Pack file not found: ${filePath}`)
+  }
+
+  let raw: string
+  try {
+    raw = fs.readFileSync(resolvedPath, 'utf8')
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to read pack file "${filePath}": ${msg}`)
+  }
+
+  let data: unknown
+  try {
+    data = JSON.parse(raw)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Invalid JSON in pack file "${filePath}": ${msg}`)
+  }
+
+  try {
+    return validatePack(data)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Invalid pack file "${filePath}": ${msg}`)
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Convert Pack Cases to TestCase format for runner
+// ────────────────────────────────────────────────────────────────────────────
+
+export function packCasesToTestCases(pack: Pack, dimensions?: Dimension[]): TestCase[] {
+  let cases = pack.cases
+
+  // Filter by dimension if requested
+  if (dimensions && dimensions.length > 0) {
+    cases = cases.filter(c => dimensions.includes(c.dimension))
+  }
+
+  return cases.map(c => {
+    // Convert pack tool format to TestCase tool format (with type: 'function' wrapper)
+    const tools = c.tools.map(t => ({
+      type: 'function' as const,
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+      },
+    }))
+
+    // Convert expected calls to TestCase format
+    let expected: TestCase['expected']
+    if (c.expected.noCall) {
+      expected = { noCall: true }
+    } else {
+      expected = {
+        calls: (c.expected.calls ?? []).map(call => ({
+          name: call.name,
+          args: call.args ?? {},
+          argsMatchMode: 'subset' as const,
+        })),
+      }
+    }
+
+    const testCase: TestCase = {
+      id: c.id,
+      dimension: c.dimension,
+      prompt: c.prompt,
+      tools,
+      expected,
+    }
+
+    if (c.system) testCase.system = c.system
+    if (c.difficulty) testCase.difficulty = c.difficulty
+    if (c.tags) testCase.tags = c.tags
+
+    return testCase
+  })
+}

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -25,10 +25,12 @@ export async function runBenchmark(
 
   const endpoint = getEndpointDisplay(config)
 
-  const cases = selectCases(
-    options.cases,
-    options.dimensions
-  )
+  // Use custom cases from --pack if provided, otherwise fall back to built-in suite
+  const cases = options.customCases
+    ? (options.cases && options.cases < options.customCases.length
+        ? options.customCases.slice(0, options.cases)
+        : options.customCases)
+    : selectCases(options.cases, options.dimensions)
 
   callbacks?.onStart?.(cases.length, config.model, endpoint)
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -170,4 +170,6 @@ export interface RunOptions {
   concurrency?: number
   dryRun?: boolean
   verbose?: boolean
+  /** Custom test cases (e.g. from a --pack file). When set, overrides built-in suite. */
+  customCases?: TestCase[]
 }


### PR DESCRIPTION
## Summary

Adds `--pack <path>` flag to benchmark against custom tool schemas instead of the built-in test suite.

## Files Created / Modified

### New Files
- **`src/core/pack.ts`** — Core pack module with:
  - `PackCase` and `Pack` TypeScript interfaces
  - `loadPack(filePath)` — reads JSON file, validates, throws helpful errors
  - `validatePack(data)` — validates structure with clear error messages
  - `packCasesToTestCases()` — converts pack format to runner-compatible `TestCase[]`
- **`src/core/__tests__/pack.test.ts`** — 28 tests covering: valid pack, bad JSON, missing fields, invalid dimensions, dimension filtering, empty cases array, tool format conversion

### Modified Files
- **`src/cli/index.ts`** — Added `--pack <path>` option; loads pack and passes `customCases` to runner
- **`src/types/index.ts`** — Added `customCases?: TestCase[]` to `RunOptions`
- **`src/core/runner.ts`** — Uses `customCases` when provided instead of built-in suite

## Usage

```bash
# Run with a custom pack
toolscore --model openai/gpt-4o --pack ./my-tools.json

# Filter to a specific dimension from the pack
toolscore --model openai/gpt-4o --pack ./my-tools.json --dimension selection
```

## Tests

**28 tests passing** across:
- Valid pack acceptance (all 5 dimensions)
- Empty cases array
- `noCall` expected format
- Optional fields (system, difficulty, tags)
- Missing top-level fields (version, name, cases)
- Invalid dimension values (with helpful error listing valid options)
- Missing case fields (id, prompt, tools, expected)
- Empty tools array
- File loading (not found, invalid JSON, invalid structure)
- Dimension filtering (single, multiple, no match)
- Tool format conversion (type:function wrapper)
- `argsMatchMode` defaulting to `subset`
- `noCall` passthrough
- Empty pack